### PR TITLE
add zero_division = 0 to presision score and recall

### DIFF
--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -131,8 +131,8 @@ class GrantTagger():
         scores = {
             'accuracy': accuracy_score(y, y_predict),
             'f1': f1_score(y, y_predict),
-            'precision_score': precision_score(y, y_predict),
-            'recall_score': recall_score(y, y_predict)}
+            'precision_score': precision_score(y, y_predict, zero_division=0),
+            'recall_score': recall_score(y, y_predict, zero_division=0)}
 
         if print_results:
             print(scores)


### PR DESCRIPTION
added zero division to accuracy scores to prevent warning in grant_tagger_experiement notebook