### PR TITLE
calculate human accuracy of epmc abstract labelling 

### DIFF
--- a/nutrition_labels/human_accuracy.py
+++ b/nutrition_labels/human_accuracy.py
@@ -1,0 +1,33 @@
+import pandas as pd
+
+if __name__ == '__main__':
+
+    liz_add_epmc = pd.read_csv(
+        'data/raw/EPMC_relevant_tool_pubs_manual_edit_Lizadditions.csv',
+        encoding = "latin"
+        )
+
+    str_codes = [str(int(a)) if not pd.isnull(a) else a for a in liz_add_epmc['code']]
+    liz_add_epmc['Nonie code'] = [a if a!='55' else '5' for a in str_codes]
+
+    print("Nonie labelled:")
+    print(liz_add_epmc.groupby(['Nonie code'])['Nonie code'].count())
+
+    print("Liz labelled:")
+    print(liz_add_epmc.groupby(['Liz code'])['Liz code'].count())
+
+    both_labelled = liz_add_epmc.dropna(subset=['Nonie code', 'Liz code'])
+
+    print("Proportion of times we exactly agree on tool, dataset, model, not relevant")
+    hard_agree = both_labelled[both_labelled['Nonie code']==both_labelled['Liz code']]
+    print(len(hard_agree)/len(both_labelled))
+    # print(hard_agree[['Nonie code', 'Liz code']])
+
+    print("Proportion of times we agree on relevant/not relevent")
+    soft_agree = both_labelled[(
+        (both_labelled['Nonie code']=='5') & (both_labelled['Liz code']=='5')
+        ) | (
+        (both_labelled['Nonie code']!='5') & (both_labelled['Liz code']!='5')
+        )]
+    print(len(soft_agree)/len(both_labelled))
+    print(soft_agree[['Nonie code', 'Liz code']])


### PR DESCRIPTION
adds little script to calculate human accuracy between epmc data labels.


as of 9th july the output of this is:
```
Nonie labelled:
Nonie code
1     38
2     13
3      7
4      9
5    501
6     49
Name: Nonie code, dtype: int64
Liz labelled:
Liz code
1    29
2    11
3     9
5    51
?     1
Name: Liz code, dtype: int64
Proportion of times we exactly agree on tool, dataset, model, not relevant
0.39215686274509803
Proportion of times we agree on relevant/not relevent
0.5490196078431373
    Nonie code Liz code
4            5        5
6            1        1
14           5        5
22           5        5
23           5        5
30           6        1
33           5        5
34           5        5
53           5        5
54           5        5
59           5        5
60           5        5
63           5        5
66           5        5
107          4        1
112          1        1
130          3        1
135          1        1
137          6        2
140          1        1
146          1        1
148          4        1
286          1        1
320          3        2
335          1        1
341          6        2
391          1        1
398          1        2
```