### PR TITLE
Results table

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,17 @@ source build/virtualenv/bin/activate
 jupyter notebook
 ```
 
+## grant_tagger.py
+
+You can train and save a model to classify grants as being to do with tech or not (see definitions for this in `Finding_Relevant_Grants.md`) by running:
+
+```
+python nutrition_labels/grant_tagger.py --training_data_file 'data/processed/training_data.csv' --vectorizer_type 'count' --relevant_sample_ratio 1 --model_type naive_bayes --bert_type 'bert'
+```
+
+where `vectorizer_type` can be 'count', 'tfidf' or 'bert', `model_type` can be 'naive_bayes', 'SVM' and 'log_reg', and `bert_type` (if using bert) can be 'bert' and 'scibert'.
+
+
 ## Project structure
 
 ```

--- a/docs/Finding_Relevant_Grants.md
+++ b/docs/Finding_Relevant_Grants.md
@@ -140,4 +140,6 @@ In `grant_tagger.py` we train a model to predict whether a grant is relevant or 
 | 200806 | (1,2) | 0.25 | tfidf | naive_bayes | - | 1.0 | 438 | 146 | 0.991 | 0.718 |
 | 200806 | (1,2) | 0.25 | tfidf | SVM | - | 1.0 | 438 | 146 | 0.998 | 0.759 |
 | 200806 | (1,2) | 0.25 | bert | naive_bayes | bert | 1.0 | 438 | 146 | 0.754 | 0.667 |
-| 200806 | (1,2) | 0.25 | bert | SVM | bert | 1.0 | 438 | 146 | 0.85 | 0.794 |
+| 200806 | (1,2) | 0.25 | bert | SVM | bert | 1.0 | 438 | 146 | 0.850 | 0.794 |
+| 200806 | (1,2) | 0.25 | bert | log_reg | bert | 1.0 | 438 | 146 | 0.993 | 0.819 |
+

--- a/docs/Finding_Relevant_Grants.md
+++ b/docs/Finding_Relevant_Grants.md
@@ -6,16 +6,16 @@ Thus, we will create a model to predict whether a grant was likely to contribute
 
 ## Relevant grants
 
-### Definitions 
+### Definitions
 
 - Tool: Any peice of code or script that is used on a medical data set to process it for further analysis. Tasks that this includes can be, cleaning data, linking two data sets, annotating data or a platform or web resource for data
-- Model: Any machine learning or statistical model that can be translated to a clinical enviroment, not to offer further insight for scientific research 
-- Medical Data Set: a data set containing at least in part medical data such as genetic data linked with a specific disease, electronic health records or imaging data 
+- Model: Any machine learning or statistical model that can be translated to a clinical enviroment, not to offer further insight for scientific research
+- Medical Data Set: a data set containing at least in part medical data such as genetic data linked with a specific disease, electronic health records or imaging data
 
-### Assumptions 
+### Assumptions
 
-- Tools or models that created a normal or healthy model of medical data such as a healthy (human) MRI scan or ECG were defined as tool 
-- Tools that annotated genetic regions were not included as tools unless they were linking them specifically to a human disease 
+- Tools or models that created a normal or healthy model of medical data such as a healthy (human) MRI scan or ECG were defined as tool
+- Tools that annotated genetic regions were not included as tools unless they were linking them specifically to a human disease
 - Code lists for determining patients with diseases in electronic health records were labeled as tools
 - In tagging publication abstracts: mention of producing a particularly novel piece of software/model but only broadly related to humans (e.g. genetics), not a specific human disease, is still ok to include as a tool or model
 - In tagging publication abstracts: a publication specifically about clinical trial results will often mention data collection, but we won't tag this as being about a dataset since it was created as a byproduct of investigating something else, not an end in itself
@@ -33,10 +33,10 @@ There were three possible data sources we looked at when tagging whether a grant
 
 The first step was reading the grant descriptions and trying to discern if they were relevant or not. It became clear that a really small proportion were relevant. The grants were filtered first to speed up this process, the filters applied were:
 
-The grant descriptions were filtered if the following key words were found in the grant description: 
+The grant descriptions were filtered if the following key words were found in the grant description:
 ['platform','software','library','mining','web resouce','data management','pipeline','tool','biobank','health data','medical records']
 
-It should be noted that when searching for these words there was no space put before mining so it returned grant descriptions with words like determining etc. 
+It should be noted that when searching for these words there was no space put before mining so it returned grant descriptions with words like determining etc.
 
 873 of these grants were tagged as
 - 1 = Relevant
@@ -107,27 +107,37 @@ Not all the tagged data from ResearchFish (5 grants) or the EPMC publications (7
 
 This dataset comprises of a grant reference, the grant title and description and also the tagged code.
 
-### Training data summary - 30th June 2020 
+### Training data summary - 30th June 2020
 
 | Tag code | Meaning | Number of grants |
-|---|---|--- | 
+|---|---|--- |
 | 1 | Relevant tool | 41 |
 | 2 | Relevant model | 14 |
 | 3 | Relevant dataset | 13 |
 | 5 | Not relevant | 791 |
 
-### Training data summary - 15th July 2020 
+### Training data summary - 15th July 2020
 
 | Tag code | Meaning | Number of grants |
-|---|---|--- | 
+|---|---|--- |
 | 1 | Relevant | 292 |
 | 0 | Not relevant | 989 |
 
 ## `grant_tagger.py`
 
-In `grant_tagger.py` we train a model to predict whether a grant is relevant or not. For this we collapsed the classification into binary, where 
+In `grant_tagger.py` we train a model to predict whether a grant is relevant or not. For this we collapsed the classification into binary, where
 - 1 = class was relevant tool (1), relevant model (2) or relevant dataset (3)
 - 0 = class was not relevant (5)
 
+## Model Results
 
-
+| Date | ngram range | Test proportion | Vectorizer type | Model type | Bert type (if relevant) | Not relevent sample size | Train size | Test size | Train F1 | Test F1 |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 200806 | (1,2) | 0.25 | count | log_reg | - | 1.0 | 438 | 146 | 0.998 | 0.778 |
+| 200806 | (1,2) | 0.25 | count | naive_bayes | - | 1.0 | 438 | 146 | 0.998 | 0.829 |
+| 200806 | (1,2) | 0.25 | count | SVM | - | 1.0 | 438 | 146 | 0.982 | 0.803 |
+| 200806 | (1,2) | 0.25 | tfidf | log_reg | - | 1.0 | 438 | 146 | 0.998 | 0.828 |
+| 200806 | (1,2) | 0.25 | tfidf | naive_bayes | - | 1.0 | 438 | 146 | 0.991 | 0.718 |
+| 200806 | (1,2) | 0.25 | tfidf | SVM | - | 1.0 | 438 | 146 | 0.998 | 0.759 |
+| 200806 | (1,2) | 0.25 | bert | naive_bayes | bert | 1.0 | 438 | 146 | 0.754 | 0.667 |
+| 200806 | (1,2) | 0.25 | bert | SVM | bert | 1.0 | 438 | 146 | 0.85 | 0.794 |

--- a/docs/Finding_Relevant_Grants.md
+++ b/docs/Finding_Relevant_Grants.md
@@ -142,4 +142,7 @@ In `grant_tagger.py` we train a model to predict whether a grant is relevant or 
 | 200806 | (1,2) | 0.25 | bert | naive_bayes | bert | 1.0 | 438 | 146 | 0.754 | 0.667 |
 | 200806 | (1,2) | 0.25 | bert | SVM | bert | 1.0 | 438 | 146 | 0.850 | 0.794 |
 | 200806 | (1,2) | 0.25 | bert | log_reg | bert | 1.0 | 438 | 146 | 0.993 | 0.819 |
+| 200806 | (1,2) | 0.25 | bert | naive_bayes | scibert | 1.0 | 438 | 146 | 0.809 | 0.735 |
+| 200806 | (1,2) | 0.25 | bert | SVM | scibert | 1.0 | 438 | 146 | 0.821 | 0.738 |
+| 200806 | (1,2) | 0.25 | bert | log_reg | scibert | 1.0 | 438 | 146 | 0.998 | 0.814 |
 

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -261,6 +261,14 @@ if __name__ == '__main__':
     # y = data['Relevance code']
     # grant_tagger_loaded.evaluate(X_vect, y, print_results=True, average='binary')
 
+    # # Split the train and test and evaluate
+    # X_train, X_test, y_train, y_test = grant_tagger_loaded.split_data(
+    #     X_vect,
+    #     y,
+    #     relevant_sample_ratio=args.relevant_sample_ratio,
+    #     irrelevant_sample_seed=4,
+    #     split_seed=4)
 
-
+    # grant_tagger_loaded.evaluate(X_train, y_train, print_results=True)
+    # grant_tagger_loaded.evaluate(X_test, y_test, print_results=True)
 

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -31,6 +31,7 @@ class GrantTagger():
         self.vectorizer_type = vectorizer_type
         self.model_type = model_type
         self.bert_type = bert_type
+
     def transform(self, data):
 
         self.X = data['Description'].tolist()
@@ -60,8 +61,9 @@ class GrantTagger():
 
         return X_vect, y
 
-    def split_data(self, X_vect,y, relevant_sample_ratio, irrelevant_sample_seed,split_seed):
+    def split_data(self, X_vect, y, relevant_sample_ratio, irrelevant_sample_seed, split_seed):
 
+        self.relevant_sample_ratio = relevant_sample_ratio
         relevant_sample_index = [ind for ind,x in enumerate(y) if x != 0]
         irrelevant_sample_index = [ind for ind, x in enumerate(y) if x == 0]
         sample_size = int(round(len(relevant_sample_index) * relevant_sample_ratio))
@@ -122,60 +124,32 @@ class GrantTagger():
                                 'Predicted_label':y_pred})
         return X_text_df
 
-    def save_model(self, model_path):
-        with open(model_path, 'wb') as f:
+    def save_model(self, output_path, evaluation_results=None):
+        if not os.path.exists(output_path):
+            os.makedirs(output_path)
+
+        with open(os.path.join(output_path, 'model.pickle'), 'wb') as f:
             pickle.dump(self.model, f)
+        with open(os.path.join(output_path, 'vectorizer.pickle'), 'wb') as f:
+            pickle.dump(self.vectorizer, f)
 
-    def load_model(self, model_path):
-        with open(model_path, 'rb') as f:
+        if evaluation_results:
+            with open(os.path.join(output_path, 'training_information.txt'), 'w') as f:
+                f.write('ngram_range: ' + str(self.ngram_range))
+                f.write('\ntest_size: ' + str(self.test_size))
+                f.write('\nVectorizer type: ' + self.vectorizer_type)
+                f.write('\nModel type: ' + self.model_type)
+                f.write('\nBert type (if relevant): ' + self.bert_type)
+                f.write('\nNot relevent sample size: ' + str(self.relevant_sample_ratio))
+                for key, value in evaluation_results.items():
+                    f.write('\n' + key + ': ' + str(value))
+
+    def load_model(self, output_path):
+        with open(os.path.join(output_path, 'model.pickle'), 'rb') as f:
             self.model = pickle.load(f)
+        with open(os.path.join(output_path, 'vectorizer.pickle'), 'rb') as f:
+            self.vectorizer = pickle.load(f)
 
-
-def grant_tagger_experiment(
-        data,
-        relevant_sample_ratio =1,
-        vectorizer_type = 'count',
-        model_type ='naive_bayes',
-        bert_type = 'bert',
-        print_output = True
-        ):
-
-    grant_tagger = GrantTagger(
-        ngram_range=(1, 2),
-        test_size=0.25,
-        vectorizer_type= vectorizer_type,
-        model_type=model_type,
-        bert_type = bert_type
-    )
-    X_vect, y = grant_tagger.transform(data)
-    X_train, X_test, y_train, y_test = grant_tagger.split_data(
-        X_vect,
-        y,
-        relevant_sample_ratio = relevant_sample_ratio,
-        irrelevant_sample_seed = 4,
-        split_seed=4)
-
-    grant_tagger.fit(X_train, y_train)
-
-    if print_output:
-        print('\nNot relevent sample size: ' + str(relevant_sample_ratio))
-        print('\nVectorizer type: ' + vectorizer_type)
-        print('\nModel type: ' + model_type)
-        print("\nEvaluate training data")
-        grant_tagger.evaluate(X_train, y_train)
-        print("\nEvaluate test data")
-        grant_tagger.evaluate(X_test, y_test)
-        print('\nTraining descriptions')
-        print(grant_tagger.return_mislabeled_data(y_train, grant_tagger.predict(X_train), grant_tagger.train_indices))
-        print('\nTest description')
-        test_descriptions = grant_tagger.return_mislabeled_data(y_test,
-                                                                grant_tagger.predict(X_test),
-                                                                grant_tagger.test_indices)
-        print(test_descriptions)
-        print("\nMislabled Grant descriptions")
-        print(test_descriptions[test_descriptions['True_label'] != test_descriptions['Predicted_label']])
-
-    return grant_tagger
 
 def create_argparser():
 
@@ -219,17 +193,36 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     data = pd.read_csv(args.training_data_file)
-
-    grant_tagger = grant_tagger_experiment(
-        data,
-        relevant_sample_ratio=args.relevant_sample_ratio,
+   
+    grant_tagger = GrantTagger(
+        ngram_range=(1, 2),
+        test_size=0.25,
         vectorizer_type=args.vectorizer_type,
         model_type=args.model_type,
         bert_type=args.bert_type
-        )
+    )
+
+    X_vect, y = grant_tagger.transform(data)
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(
+        X_vect,
+        y,
+        relevant_sample_ratio=args.relevant_sample_ratio,
+        irrelevant_sample_seed=4,
+        split_seed=4)
+
+    grant_tagger.fit(X_train, y_train)
+
+    train_scores = grant_tagger.evaluate(X_train, y_train, print_results=True)
+    test_scores = grant_tagger.evaluate(X_test, y_test, print_results=True)
+    evaluation_results = {
+        'Train scores': train_scores,
+        'Test scores': test_scores,
+        'Train size': len(y_train),
+        'Test size': len(y_test)
+        }
     
     outout_name = '_'.join(
-        [args.vectorizer_type, str(args.relevant_sample_ratio), args.model_type]
+        [args.vectorizer_type, args.model_type]
         )
     if args.bert_type and args.vectorizer_type=='bert':
         outout_name = '_'.join([outout_name, args.bert_type])
@@ -237,11 +230,37 @@ if __name__ == '__main__':
     datestamp = datetime.now().date().strftime('%y%m%d')
     outout_name = '_'.join([outout_name, datestamp])
 
-    grant_tagger.save_model(os.path.join('models', outout_name))
+    grant_tagger.save_model(
+        os.path.join('models', outout_name),
+        evaluation_results=evaluation_results,
+        )
 
-    # grant_tagger_experiment(data,vectorizer_type='bert',model_type='SVM')
-    # grant_tagger_experiment(data,vectorizer_type='bert',model_type='log_reg')
-    # grant_tagger_experiment(data,vectorizer_type='bert',bert_type= 'scibert')
-    # grant_tagger_experiment(data,vectorizer_type='bert', model_type='SVM',bert_type= 'scibert')
-    # grant_tagger_experiment(data,vectorizer_type='bert', model_type='log_reg',bert_type= 'scibert')
+    # print('\nTraining descriptions')
+    # print(grant_tagger.return_mislabeled_data(y_train, grant_tagger.predict(X_train), grant_tagger.train_indices))
+    # print('\nTest description')
+    # test_descriptions = grant_tagger.return_mislabeled_data(y_test,
+    #                                                         grant_tagger.predict(X_test),
+    #                                                         grant_tagger.test_indices)
+    # print(test_descriptions)
+    # print("\nMislabled Grant descriptions")
+    # print(test_descriptions[test_descriptions['True_label'] != test_descriptions['Predicted_label']])
+
+    # # Loading a trained model and vectorizer to predict new data:
+
+    # grant_tagger_loaded = GrantTagger()
+    # grant_tagger_loaded.load_model(os.path.join('models', 'count_naive_bayes_200806'))
+
+    # new_grants = [
+    #     'Is this a grant about tools and stuff like models',
+    #     'in this grant I created a model of the human health care system in the UK. The model is open source and several python software packages have been released.']
+    # new_grants_vect = grant_tagger_loaded.vectorizer.transform(new_grants)
+    # grant_tagger_loaded.predict(new_grants_vect)
+
+    # # Predict all the training data
+    # X_vect = grant_tagger_loaded.vectorizer.transform(data['Description'].tolist())
+    # y = data['Relevance code']
+    # grant_tagger_loaded.evaluate(X_vect, y, print_results=True, average='binary')
+
+
+
 


### PR DESCRIPTION
Addresses https://github.com/wellcometrust/nutrition-labels/issues/23

Edits to grant_tagger.py to:
- add arguments to run this code, now you can run
```
python nutrition_labels/grant_tagger.py --training_data_file 'data/processed/training_data.csv' --vectorizer_type 'count' --relevant_sample_ratio 1 --model_type naive_bayes --bert_type 'bert'
```
with whatever arguments you want and the model will be trained and saved.

- save model, vectorizer, and model description and results.
- load model and vecotrizer and commented out code on how to use these
- Added a table of results to the md file

Warning: the bert fitted vectorizers that get saved can be quite big (439MB, non bert ones are like 4MB), so you might want to delete if you dont need them