### PR TITLE
Fix EPMC training data bug

### DIFF
--- a/configs/training_data/2020.08.07.ini
+++ b/configs/training_data/2020.08.07.ini
@@ -5,6 +5,7 @@ description = Creating the training data with tech definition being UK-based and
 [data]
 epmc_tags_query_one_filedir = data/raw/EPMC_relevant_tool_pubs_3082020.csv
 epmc_tags_query_two_filedir = data/raw/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
 rf_tags_filedir = data/raw/ResearchFish/research_fish_manual_edit.csv
 grant_tags_filedir = data/raw/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
 grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv

--- a/configs/training_data/2021.01.26.ini
+++ b/configs/training_data/2021.01.26.ini
@@ -5,6 +5,7 @@ description = Creating the training data with tech definition being world-wide a
 [data]
 epmc_tags_query_one_filedir = data/raw/expanded_tags/EPMC_relevant_tool_pubs_3082020.csv
 epmc_tags_query_two_filedir = data/raw/expanded_tags/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
 rf_tags_filedir = data/raw/expanded_tags/research_fish_manual_edit.csv
 grant_tags_filedir = data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
 grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv

--- a/docs/Finding_Tech_Grants.md
+++ b/docs/Finding_Tech_Grants.md
@@ -99,6 +99,14 @@ We didn't include publications already found from the first query.
 
 This yielded 9709 publications outputted in `EPMC_relevant_pubs_query2.csv`.
 
+#### Excel EPMC grants list corruption
+
+The EPMC data has a comma separated list of grant numbers associated with each pmid. During the tagging of the EPMC data using Excel this list is corrupted - Excel converts it to one number and will round to 15 significant figures - therefore a list of more than 2 6-digit grant numbers will be corrupted. For example, "086151,104104,196287" becomes "86,151,104,104,196,200". Therefore we process the raw EPMC data into a dictionary of `pmid: list of grant numbers`. This dictionary can be used to get the grant numbers rather than using the corrupted numbers in the tagged EPMC csvs. This is done by running:
+ 
+```
+python nutrition_labels/create_epmc_dict.py --epmc_query_one_path data/raw/EPMC/EPMC_relevant_tool_pubs.csv --epmc_query_two_path data/raw/EPMC/EPMC_relevant_pubs_query2.csv --output_path data/raw/EPMC/pmid2grants.json
+```
+
 ## Compiling the training data
 
 By running `python nutrition_labels/grant_data_processing.py` the three sets of tagged training data are combined with the publically available grants data `data/raw/wellcome-grants-awarded-2005-2019.csv`. This is outputted in `data/processed/training_data.csv`.

--- a/nutrition_labels/create_epmc_dict.py
+++ b/nutrition_labels/create_epmc_dict.py
@@ -1,0 +1,33 @@
+"""
+Small script to take EPMC data and create a dictionary of pmid: list of grants
+
+This is because the manually labelled (in Excel) data becomes slightly corrupted:
+e.g. in the original data the list of grants
+086151,104104,104104
+becomes
+86,151,104,104,104,100
+due to Excel processing it as a number not a string and rounding.
+The rounding caused the wrong grants linked or grants not being found.
+"""
+
+import json
+
+import pandas as pd
+
+# Original EPMC data from fortytwo (not manually labelled)
+epmc_query_one = pd.read_csv('data/raw/EPMC/EPMC_relevant_tool_pubs.csv')
+epmc_query_two = pd.read_csv('data/raw/EPMC/EPMC_relevant_pubs_query2.csv')
+
+epmc_data = pd.concat([epmc_query_one, epmc_query_two], ignore_index=True)
+
+# No use adding to the dictionary if no grant numbers are given
+epmc_data.dropna(subset=['WTgrants'], inplace=True)
+
+# Split grants by comma
+epmc_data['WTgrants'] = epmc_data['WTgrants'].apply(lambda x: x.split(','))
+epmc_data['pmid'] = epmc_data['pmid'].astype(str)
+
+pmid2grants = epmc_data.set_index('pmid').to_dict()['WTgrants']
+
+with open('data/raw/EPMC/pmid2grants.json', 'w') as json_file:
+    json.dump(pmid2grants, json_file)

--- a/nutrition_labels/create_epmc_dict.py
+++ b/nutrition_labels/create_epmc_dict.py
@@ -11,23 +11,44 @@ The rounding caused the wrong grants linked or grants not being found.
 """
 
 import json
+from argparse import ArgumentParser
 
 import pandas as pd
 
-# Original EPMC data from fortytwo (not manually labelled)
-epmc_query_one = pd.read_csv('data/raw/EPMC/EPMC_relevant_tool_pubs.csv')
-epmc_query_two = pd.read_csv('data/raw/EPMC/EPMC_relevant_pubs_query2.csv')
+if __name__ == '__main__':
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--epmc_query_one_path',
+        help='Path to first query EPMC raw data csv',
+        default='data/raw/EPMC/EPMC_relevant_tool_pubs.csv'
+    )
+    parser.add_argument(
+        '--epmc_query_two_path',
+        help='Path to second query EPMC raw data csv',
+        default='data/raw/EPMC/EPMC_relevant_pubs_query2.csv'
+    )
+    parser.add_argument(
+        '--output_path',
+        help='Path for outputted PMID-grantID dict',
+        default='data/raw/EPMC/pmid2grants.json'
+    )
+    args = parser.parse_args()
 
-epmc_data = pd.concat([epmc_query_one, epmc_query_two], ignore_index=True)
+    # Original EPMC data from fortytwo (not manually labelled)
+    epmc_query_one = pd.read_csv(args.epmc_query_one_path)
+    epmc_query_two = pd.read_csv(args.epmc_query_two_path)
 
-# No use adding to the dictionary if no grant numbers are given
-epmc_data.dropna(subset=['WTgrants'], inplace=True)
+    epmc_data = pd.concat([epmc_query_one, epmc_query_two], ignore_index=True)
 
-# Split grants by comma
-epmc_data['WTgrants'] = epmc_data['WTgrants'].apply(lambda x: x.split(','))
-epmc_data['pmid'] = epmc_data['pmid'].astype(str)
+    # No use adding to the dictionary if no grant numbers are given
+    epmc_data.dropna(subset=['WTgrants'], inplace=True)
 
-pmid2grants = epmc_data.set_index('pmid').to_dict()['WTgrants']
+    # Split grants by comma
+    epmc_data['WTgrants'] = epmc_data['WTgrants'].apply(lambda x: x.split(','))
+    epmc_data['pmid'] = epmc_data['pmid'].astype(str)
 
-with open('data/raw/EPMC/pmid2grants.json', 'w') as json_file:
-    json.dump(pmid2grants, json_file)
+    pmid2grants = epmc_data.set_index('pmid').to_dict()['WTgrants']
+
+    with open(args.output_path, 'w') as json_file:
+        json.dump(pmid2grants, json_file)
+

--- a/nutrition_labels/grant_data_processing.py
+++ b/nutrition_labels/grant_data_processing.py
@@ -40,11 +40,7 @@ def clean_grants_data(old_grant_data):
     grant_data.reset_index(inplace=True) # After dropping rows you need to reset this
     return grant_data
 
-def process_epmc(epmc_tags_query_one, epmc_tags_query_two, epmc_code_dict, col_ranking_list):
-
-    # Get pmid2grants dict
-    with open('data/raw/EPMC/pmid2grants.json') as f:
-        pmid2grants = json.load(f)
+def process_epmc(epmc_tags_query_one, epmc_tags_query_two, epmc_code_dict, col_ranking_list, pmid2grants):
 
     # Merge EPMC data and normalise the codes
     # Order of truth (if same row has been labelled): Becky > Nonie > Liz > Aoife
@@ -152,13 +148,18 @@ if __name__ == '__main__':
     rf_code_dict = {'1': 1, '2': 2, '3': 3, '4': None, '5': None}
     grants_code_dict = {'1': 1, '4': None, '5': 5}
 
+    # Load pmid2grants dict for EPMC data
+    with open(config["data"]["epmc_pmid2grants_dir"]) as f:
+        pmid2grants = json.load(f)
+
     # Process each of the 3 data sources separately and output a 
     # dataframe for each of grant numbers - cleaned tags links
     epmc_df = process_epmc(
         epmc_tags_query_one,
         epmc_tags_query_two,
         epmc_code_dict,
-        epmc_col_ranking
+        epmc_col_ranking,
+        pmid2grants
         )
     rf_df = process_RF(rf_tags, rf_code_dict)
     grants_df = process_grants(grant_tags, grants_code_dict, grants_col_ranking)

--- a/nutrition_labels/grant_data_processing.py
+++ b/nutrition_labels/grant_data_processing.py
@@ -3,6 +3,7 @@ import configparser
 from argparse import ArgumentParser
 import ast
 import os
+import json
 
 import pandas as pd
 import numpy as np
@@ -41,6 +42,10 @@ def clean_grants_data(old_grant_data):
 
 def process_epmc(epmc_tags_query_one, epmc_tags_query_two, epmc_code_dict, col_ranking_list):
 
+    # Get pmid2grants dict
+    with open('data/raw/EPMC/pmid2grants.json') as f:
+        pmid2grants = json.load(f)
+
     # Merge EPMC data and normalise the codes
     # Order of truth (if same row has been labelled): Becky > Nonie > Liz > Aoife
     epmc_tags = pd.concat([epmc_tags_query_one, epmc_tags_query_two], ignore_index=True)
@@ -54,31 +59,12 @@ def process_epmc(epmc_tags_query_one, epmc_tags_query_two, epmc_code_dict, col_r
     # Create list of dicts for each WT grant number given
     epmc_list = []
     for i, row in epmc_tags.iterrows():
-        grant_num = row['WTgrants']
-        if len(grant_num) == 5:
-            grant_num = ['0' + grant_num]
-        elif len(grant_num) > 6:
-            count = 1
-            merged_grant_chunk = ''
-            merge_grant_nums = list()
-            for grant_chunk in grant_num.split(','):
-                if len(grant_chunk) ==2:
-                    grant_chunk = '0' + grant_chunk
-                if count == 2:
-                    merge_grant_nums.append(merged_grant_chunk + grant_chunk)
-                    merged_grant_chunk = ''
-                    count = 1
-                elif count == 1:
-                    merged_grant_chunk = grant_chunk
-                    count = count + 1
-            merge_grant_nums = [nums for nums in merge_grant_nums if nums != '000000']
-            grant_num = merge_grant_nums
-        else:
-            grant_num = [grant_num]
-        for num in grant_num:
-            epmc_list.append({'pmid':row['pmid'],
-                              'Normalised code - EPMC':int(row['Normalised code']),
-                              'Internal ID 6 digit':num,})
+        pmid = str(row['pmid']) # Can sometimes be int
+        grants = pmid2grants.get(pmid)
+        for grant in grants:
+            epmc_list.append({'pmid': pmid,
+                              'Normalised code - EPMC': int(row['Normalised code']),
+                              'Internal ID 6 digit': grant,})
 
     epmc_df = pd.DataFrame(epmc_list)
     epmc_df.drop_duplicates(subset=['Internal ID 6 digit', 'Normalised code - EPMC'], inplace=True)


### PR DESCRIPTION
I found a bug in the EPMC data. Because we manually tagged in Excel, the original format for the list of grants for each publication was changed to a number and rounded.

e.g.
086151,104104,196287
became
86,151,104,104,196,200

we previously had some logic to deal with the grant numbers split, but the rounding issue is actually a bug.

This PR solves this by creating a dictionary of {pmid: [grants list]} using the original (uncorrupted) EPMC data. Then this dict can be read in to get the list of grants. It also means all the complicated logic isn't needed anymore which is nice.

This bug effects 9 grants (out of 700) previously in the training data that shouldn't be:
`{'098000/Z/11/Z', '104100/Z/14/Z', '102200/Z/13/Z', '086000/Z/08/Z', '100000/Z/12/Z', '203100/Z/16/Z', '090300/Z/09/Z', '101200/Z/13/Z', '091300/Z/10/Z'}`

And 9 grants that should be in the training data which weren't previously included:
`{'097835/Z/11/B', '107881/Z/15/Z', '100140/Z/12/B', '095552/Z/11/Z', '092311/Z/10/Z', '203139/Z/16/Z', '102215/Z/13/B', '101237/Z/13/B', '106130/Z/14/B'}`