### PR TITLE
Analysis on the training data

### DIFF
--- a/docs/Training_data_sources.md
+++ b/docs/Training_data_sources.md
@@ -1,0 +1,98 @@
+
+In the notebook `notebooks/Training data analysis.ipynb` I had a look at the extent and effect of the different sources of training data. I wanted to answer 3 broad questions:
+
+1. How much training data comes from each of the 4 tagging sources:
+- EPMC
+- Research Fish
+- Grants via Excel
+- Grants via Prodigy active learning
+2. How well does the 210223 ensemble do for each of these 4 sources?
+3. Does training the models with no EPMC or RF training data contributions improve the model?
+
+This analysis was performed on the following data:
+1. The training data that went into Prodigy : `../data/processed/training_data/210126/training_data.csv`
+2. The final Prodigy merged results (original training + new tags) : `../data/prodigy/merged_tech_grants/merged_tech_grants.jsonl`
+3. Which grants were from the test set for the 210221 model runs: `../data/processed/model_test_results/test_data_210221.csv`
+4. The predictions on all grants from the 210223 Ensemble model (which used the 210221 models): `../data/processed/ensemble/210223/wellcome-grants-awarded-2005-2019_tagged.csv`
+
+# 1. How much training data comes from each of the 4 tagging sources?
+
+The training data is labelled from:
+- Multiple sources: 26
+- RF: 57 (57 'tech')
+- EPMC: 126 (126 'tech')
+- Grants: 485 (138 'tech', 347 'not tech)
+- Prodigy only: 286 (150 'tech', 136 'not tech)
+
+Of the 26 multiple sources only 3 were not in agreement:
+- 3 times the grant description was labelled 'not tech', but RF data labelled as 'tech'
+- 0 times the grant description was labelled 'not tech', but EPMC data labelled as 'tech'
+- 3 times the grant description and RF labels both said tech
+- 13 times the grant description and EPMC labels both said tech
+- 7 times both EPMC and RF labels said tech
+
+# 2. How well does the 210223 ensemble do for each of these 4 sources?
+
+Using the test data (i.e. not any data that went into training the models), the 210223 ensemble model performs differently for data points labelled from the different sources.
+
+- Of the 19 ResearchFish labelled data points (all labelled as tech) **0.632** were correctly labelled as tech when using the grant description.
+- Of the 35 EPMC labelled data points (all labelled as tech) **0.714** were correctly labelled as tech when using the grant description.
+
+When tagging a grant as tech or not from the original grant descriptions the model performs better:
+- 114 original grants via Excel: 'precision': 0.805, 'recall': **0.892**, 'f1': 0.846
+- 73 grants tagged via Prodigy: 'precision': 0.771, 'recall': **0.902**, 'f1': 0.831
+- 187 grants **either** tagged via Excel or Prodigy: 'precision': 0.787, 'recall': **0.897**, 'f1': 0.838
+
+Ensemble performance on all test data (recap):
+- 241 grants: 'precision': 0.849, 'recall': 0.811, 'f1': 0.829
+
+# 3. Does training the models with no EPMC or RF training data contributions improve the model?
+
+In the notebook I output `../data/prodigy/merged_tech_grants/merged_tech_grants_noepmcrf.jsonl` which is the Prodigy outputted data (`'../data/prodigy/merged_tech_grants/merged_tech_grants.jsonl'`) minus the additions from the EPMC or RF tagged training data (from the `training_data/210126/training_data.csv` training data).
+
+This can be run in `prodigy_training_data.py` to create a new training data csv:
+```
+python -i nutrition_labels/prodigy_training_data.py --prodigy_data_dir 'data/prodigy/merged_tech_grants/merged_tech_grants_noepmcrf.jsonl'
+```
+which outputted `training_data/210305/training_data.csv`. 
+
+| Tag code | Meaning | Number of grants - 210221 | Number of grants - 210305 |
+|---|---|--- |--- |
+| 1 | Relevant | 495 | 306 |
+| 0 | Not relevant | 485 | 484 |
+
+Then I start running models again:
+```
+python -i nutrition_labels/grant_tagger.py --training_data_file 'data/processed/training_data/210305/training_data.csv' --vectorizer_type tfidf --model_type naive_bayes
+```
+The split seed was set to 7 - but this time I didn't run any of the 'best seed' experiments - I just kept it set to what it was at before.
+
+| Date | Vectorizer type | Model type | Bert type (if relevant) | Train F1 | Test F1 | Test precision | Test recall |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| 210221 | count | log_reg | - | 1.000 | 0.772 | 0.806 | 0.741 |
+| 210305 | count | log_reg | - | 1.000 | 0.805 | 0.831 | 0.780 |
+| 210221 | count | naive_bayes | - | 1.000 | 0.774 | 0.820 | 0.732 |
+| 210305 | count | naive_bayes | - | 1.000 | 0.836 | 0.779 | 0.902 |
+| 210221 | count | SVM | - | 0.969 | 0.720 | 0.827 | 0.637 |
+| 210305 | count | SVM | - | 0.977 | 0.748 | 0.795 | 0.707 |
+| 210221 | tfidf | log_reg | - | 0.997 | 0.759 | 0.814 | 0.711 |
+| 210305 | tfidf | log_reg | - | 1.000 | 0.829 | 0.90 | 0.768 |
+| 210221 | tfidf | naive_bayes | - | 0.999 | 0.817 | 0.779 | 0.859 |
+| 210305 | tfidf | naive_bayes | - | 1.000 | 0.825 | 0.768 | 0.890 |
+| 210221 | tfidf | SVM | - | 1.000 | 0.736 | 0.846 | 0.652 |
+| 210305 | tfidf | SVM | - | 1.000 | 0.778 | 0.903 | 0.683 |
+| 210221 | bert | naive_bayes | bert | 0.730 | 0.746 | 0.803 | 0.696 |
+| 210305 | bert | naive_bayes | bert | 0.762 | 0.775 | 0.795 | 0.756 |
+| 210221 | bert | SVM | bert | 0.803 | 0.780 | 0.815 | 0.748 |
+| 210305 | bert | SVM | bert | 0.866 | 0.848 | 0.843 | 0.854 |
+| 210221 | bert | log_reg | bert | 0.993 | 0.789 | 0.817 | 0.763 |
+| 210305 | bert | log_reg | bert | 1.000 | 0.888 | 0.862 | 0.915 |
+| 210221 | bert | naive_bayes | scibert | 0.764 | 0.779 | 0.803 | 0.756 |
+| 210305 | bert | naive_bayes | scibert | 0.823 | 0.795 | 0.810 | 0.780 |
+| 210221 | bert | SVM | scibert | 0.793 | 0.783 | 0.839 | 0.733 |
+| 210305 | bert | SVM | scibert | 0.835 | 0.832 | 0.848 | 0.817 |
+| 210221 | bert | log_reg | scibert | 1.000 | 0.794 | 0.819 | 0.770 |
+| 210305 | bert | log_reg | scibert | 1.000 | 0.875 | 0.897 | 0.854 |
+
+Across most of these models all metrics increase - sometimes quite dramatically (a 0.1 increase on log_reg + BERT), despite a large decrease in the training data size.
+

--- a/notebooks/Training data analysis.ipynb
+++ b/notebooks/Training data analysis.ipynb
@@ -1,0 +1,769 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "compatible-shore",
+   "metadata": {},
+   "source": [
+    "### What difference does the source of the training data tag make?\n",
+    "\n",
+    "**See how much training data came from each of the 4 tagging sources:**\n",
+    "1. EPMC\n",
+    "2. Research Fish\n",
+    "3. Grants via Excel\n",
+    "4. Grants via Prodigy active learning\n",
+    "\n",
+    "**See how well the ensemble does for each of these 4 sources.**\n",
+    "\n",
+    "### Findings:\n",
+    "\n",
+    "The training data is labelled from:\n",
+    "- Multiple sources: 26\n",
+    "- RF: 57 (57 'tech')\n",
+    "- EPMC: 126 (126 'tech')\n",
+    "- Grants: 485 (138 'tech', 347 'not tech)\n",
+    "- Prodigy only: 286 (150 'tech', 136 'not tech)\n",
+    "\n",
+    "Of the 26 multiple sources only 3 were not in agreement:\n",
+    "- 3 times the grant description was labelled 'not tech', but RF data labelled as 'tech'\n",
+    "- 0 times the grant description was labelled 'not tech', but EPMC data labelled as 'tech'\n",
+    "- 3 times the grant description and RF labels both said tech\n",
+    "- 13 times the grant description and EPMC labels both said tech\n",
+    "- 7 times both EPMC and RF labels said tech\n",
+    "\n",
+    "Using the test data (i.e. not any data that went into training the models), the 210223 ensemble model performs differently for data points labelled from the different sources.\n",
+    "\n",
+    "- Of the 19 ResearchFish labelled data points (all labelled as tech) **0.632** were correctly labelled as tech when using the grant description.\n",
+    "- Of the 35 EPMC labelled data points (all labelled as tech) **0.714** were correctly labelled as tech when using the grant description.\n",
+    "\n",
+    "When tagging a grant as tech or not from the original grant descriptions the model performs better:\n",
+    "- 114 original grants via Excel: 'precision': 0.805, 'recall': **0.892**, 'f1': 0.846\n",
+    "- 73 grants tagged via Prodigy: 'precision': 0.771, 'recall': **0.902**, 'f1': 0.831\n",
+    "- 187 grants **either** tagged via Excel or Prodigy: 'precision': 0.787, 'recall': **0.897**, 'f1': 0.838\n",
+    "\n",
+    "Ensemble performance on all test data (recap):\n",
+    "- 241 grants: 'precision': 0.849, 'recall': 0.811, 'f1': 0.829\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 71,
+   "id": "russian-cartoon",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "\n",
+    "import pandas as pd\n",
+    "from sklearn.metrics import accuracy_score, confusion_matrix, classification_report,  f1_score, precision_score, recall_score\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "polyphonic-commander",
+   "metadata": {},
+   "source": [
+    "## Load datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "another-bundle",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# 1. The training data that went into Prodigy : \n",
+    "original_training_data_dir = '../data/processed/training_data/210126/training_data.csv'\n",
+    "\n",
+    "# 2. The final Prodigy merged results (original training + new tags) :\n",
+    "prodigy_data_dir = '../data/prodigy/merged_tech_grants/merged_tech_grants.jsonl'\n",
+    "\n",
+    "# 3. Which grants were from the test set for the 210221 model runs: \n",
+    "test_data_dir = '../data/processed/model_test_results/test_data_210221.csv'\n",
+    "\n",
+    "# 4. The predictions on all grants from the 210223 Ensemble model (which used the 210221 models):\n",
+    "tech_preds_dir = '../data/processed/ensemble/210223/wellcome-grants-awarded-2005-2019_tagged.csv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "shaped-agency",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "696\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "{'Orig tech': 1, 'RF': 1, 'EPMC': None, 'Grants': 1}"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "original_training_data = pd.read_csv(original_training_data_dir)\n",
+    "original_training_data_dict = {}\n",
+    "for i, row in original_training_data.iterrows():\n",
+    "    original_training_data_dict[row['Internal ID']] = {\n",
+    "        'Orig tech': row['Relevance code'],\n",
+    "        'RF': None if pd.isnull(row['Normalised code - RF']) else 1,\n",
+    "        'EPMC': None if pd.isnull(row['Normalised code - EPMC']) else 1,\n",
+    "        'Grants': None if pd.isnull(row['Normalised code - grants']) else (0 if int(row['Normalised code - grants'])==5 else 1),\n",
+    "    }\n",
+    "print(len(original_training_data_dict))\n",
+    "original_training_data_dict['106169/Z/14/Z']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "approximate-beginning",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "980\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "1"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# All Prodigy + original data in one place\n",
+    "\n",
+    "cat2bin = {'Not tech grant': 0, 'Tech grant': 1}\n",
+    "\n",
+    "training_data = {}\n",
+    "with open(prodigy_data_dir, 'r') as json_file:\n",
+    "    for json_str in list(json_file):\n",
+    "        data = json.loads(json_str)\n",
+    "        if data['answer'] != 'ignore':\n",
+    "            label = cat2bin[data['label']]\n",
+    "            if data['answer']=='accept':\n",
+    "                rel_code = label\n",
+    "            else:\n",
+    "                # If label=1, append 0 \n",
+    "                # if label=0, append 1\n",
+    "                rel_code = abs(label - 1)\n",
+    "            training_data[data['id']] = rel_code\n",
+    "print(len(training_data))\n",
+    "training_data['106169/Z/14/Z']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "generic-parameter",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "245"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Which were the test set\n",
+    "test_data = pd.read_csv(test_data_dir)\n",
+    "test_grants = test_data['Internal ID'].tolist()\n",
+    "len(test_grants)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "parliamentary-allergy",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "16854\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "0"
+      ]
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Get the predictions\n",
+    "tech_preds = pd.read_csv(tech_preds_dir)\n",
+    "tech_preds.drop_duplicates(inplace=True)\n",
+    "tech_preds = tech_preds.set_index('Grant ID')['Tech grant prediction'].to_dict()\n",
+    "print(len(tech_preds))\n",
+    "tech_preds['220282/Z/20/Z']"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "sudden-marriage",
+   "metadata": {},
+   "source": [
+    "## Combine datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "synthetic-boulder",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data_details = []\n",
+    "for grant_number, tech_cat in training_data.items():\n",
+    "    grant_details = {'Grant number': grant_number}\n",
+    "    # Is it from the test set or training?\n",
+    "    if grant_number in test_grants:\n",
+    "        grant_details['Test/Train?'] = 'Test'\n",
+    "    else:\n",
+    "        grant_details['Test/Train?'] = 'Train'\n",
+    "        \n",
+    "    # Get prediction from ensemble model\n",
+    "    grant_details['Ensemble prediction'] = tech_preds.copy().get(grant_number)\n",
+    "    \n",
+    "    # Was it in the original training data\n",
+    "    orig_info = original_training_data_dict.copy().get(grant_number)\n",
+    "    if not orig_info:\n",
+    "        orig_info = {'Orig tech': None, 'RF': None, 'EPMC': None, 'Grants': None, 'Prodigy only': tech_cat}\n",
+    "    else: \n",
+    "        orig_info['Prodigy only'] = None\n",
+    "    orig_info['Final tech'] = tech_cat\n",
+    "    grant_details.update(orig_info)\n",
+    "    training_data_details.append(grant_details)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "dominican-cartoon",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "980"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "len(training_data_details)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 68,
+   "id": "educational-hepatitis",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "training_data_details_df = pd.DataFrame(training_data_details)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "conditional-samuel",
+   "metadata": {},
+   "source": [
+    "## Checks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "rational-model",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "True"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# if 'Orig tech' is given it should always be the same as 'Final tech'\n",
+    "orig_tech = training_data_details_df[pd.notnull(training_data_details_df['Orig tech'])]\n",
+    "all(orig_tech['Orig tech'] == orig_tech['Final tech'])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 36,
+   "id": "polished-thirty",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Multiple sources: 26\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "RF               57\n",
+       "EPMC            126\n",
+       "Grants          485\n",
+       "Prodigy only    286\n",
+       "dtype: int64"
+      ]
+     },
+     "execution_count": 36,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "multi_tag_data = training_data_details_df[pd.notnull(training_data_details_df[['RF', 'EPMC', 'Grants', 'Prodigy only']]).sum(axis=1)!=1]\n",
+    "print(f'Multiple sources: {len(multi_tag_data)}')\n",
+    "single_tag_data = training_data_details_df[pd.notnull(training_data_details_df[['RF', 'EPMC', 'Grants', 'Prodigy only']]).sum(axis=1)==1]\n",
+    "num_source = pd.notnull(single_tag_data[['RF', 'EPMC', 'Grants', 'Prodigy only']]).sum(axis=0)\n",
+    "num_source"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 144,
+   "id": "minute-somalia",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>RF</th>\n",
+       "      <th>EPMC</th>\n",
+       "      <th>Grants</th>\n",
+       "      <th>Prodigy only</th>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>Final tech</th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "      <th></th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>347</td>\n",
+       "      <td>136</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>57</td>\n",
+       "      <td>126</td>\n",
+       "      <td>138</td>\n",
+       "      <td>150</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "            RF  EPMC  Grants  Prodigy only\n",
+       "Final tech                                \n",
+       "0            0     0     347           136\n",
+       "1           57   126     138           150"
+      ]
+     },
+     "execution_count": 144,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "single_tag_data.groupby('Final tech')[['RF', 'EPMC', 'Grants', 'Prodigy only']].count()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 69,
+   "id": "conventional-gamma",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of times the grant description tag was not tech, but RF data said tech:\n",
+      "3\n",
+      "Number of times the grant description tag was not tech, but EPMC data said tech:\n",
+      "0\n",
+      "Number of times the grant description tag was tech, and RF data said tech:\n",
+      "3\n",
+      "Number of times the grant description tag was tech, and EPMC data said tech:\n",
+      "13\n",
+      "Number of times EPMC and RF said tech:\n",
+      "7\n"
+     ]
+    }
+   ],
+   "source": [
+    "# For the multiple ones, do they tend to agree?\n",
+    "print('Number of times the grant description tag was not tech, but RF data said tech:')\n",
+    "print(len(multi_tag_data.loc[((multi_tag_data['Grants']==0) & (multi_tag_data['RF']==1))]))\n",
+    "print('Number of times the grant description tag was not tech, but EPMC data said tech:')\n",
+    "print(len(multi_tag_data.loc[((multi_tag_data['Grants']==0) & (multi_tag_data['EPMC']==1))]))\n",
+    "print('Number of times the grant description tag was tech, and RF data said tech:')\n",
+    "print(len(multi_tag_data.loc[((multi_tag_data['Grants']==1) & (multi_tag_data['RF']==1))]))\n",
+    "print('Number of times the grant description tag was tech, and EPMC data said tech:')\n",
+    "print(len(multi_tag_data.loc[((multi_tag_data['Grants']==1) & (multi_tag_data['EPMC']==1))]))\n",
+    "print('Number of times EPMC and RF said tech:')\n",
+    "print(len(multi_tag_data.loc[((multi_tag_data['RF']==1) & (multi_tag_data['EPMC']==1))]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "female-france",
+   "metadata": {},
+   "source": [
+    "## Test metrics for the different sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 58,
+   "id": "confidential-corporation",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "test_single_tag_data = single_tag_data[single_tag_data['Test/Train?']=='Test']"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 103,
+   "id": "painted-appliance",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Metrics given which source\n",
+    "def get_metrics(source):\n",
+    "    source_additions = test_single_tag_data[pd.notnull(test_single_tag_data[source])]\n",
+    "    y_pred = source_additions['Ensemble prediction'].tolist()\n",
+    "    y = source_additions['Final tech'].tolist()\n",
+    "    \n",
+    "    y_tech_index = [i for i, v in enumerate(y) if v==1] # Which grant index were tech\n",
+    "    y_pred_tech = [y_pred[i] for i in y_tech_index] # The grant predictions for the tech grants only\n",
+    "    \n",
+    "    print({'precision': round(precision_score(y, y_pred, average='binary'),3),\n",
+    "         'recall': round(recall_score(y, y_pred, average='binary'),3),\n",
+    "         'f1': round(f1_score(y, y_pred, average='binary'),3),\n",
+    "           'Number tagged': len(y),\n",
+    "           'Number tagged as tech': len(y_tech_index),\n",
+    "           'Proportion predicted as tech were tech': round(sum(y_pred_tech)/len(y_tech_index),3)\n",
+    "        })\n",
+    "    return y, y_pred"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 104,
+   "id": "functional-whole",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 1.0, 'recall': 0.632, 'f1': 0.774, 'Number tagged': 19, 'Number tagged as tech': 19, 'Proportion predicted as tech were tech': 0.632}\n"
+     ]
+    }
+   ],
+   "source": [
+    "y, y_pred = get_metrics('RF')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 105,
+   "id": "super-redhead",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 1.0, 'recall': 0.714, 'f1': 0.833, 'Number tagged': 35, 'Number tagged as tech': 35, 'Proportion predicted as tech were tech': 0.714}\n"
+     ]
+    }
+   ],
+   "source": [
+    "y, y_pred = get_metrics('EPMC')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 106,
+   "id": "accredited-advertising",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 0.805, 'recall': 0.892, 'f1': 0.846, 'Number tagged': 114, 'Number tagged as tech': 37, 'Proportion predicted as tech were tech': 0.892}\n"
+     ]
+    }
+   ],
+   "source": [
+    "y, y_pred = get_metrics('Grants')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 107,
+   "id": "entire-engineer",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 0.771, 'recall': 0.902, 'f1': 0.831, 'Number tagged': 73, 'Number tagged as tech': 41, 'Proportion predicted as tech were tech': 0.902}\n"
+     ]
+    }
+   ],
+   "source": [
+    "y, y_pred = get_metrics('Prodigy only')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "intimate-relief",
+   "metadata": {},
+   "source": [
+    "### Either grants source"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 112,
+   "id": "australian-isolation",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 0.787, 'recall': 0.897, 'f1': 0.838, 'Number tagged': 187, 'Number tagged as tech': 78, 'Proportion predicted as tech were tech': 0.897}\n"
+     ]
+    }
+   ],
+   "source": [
+    "source_additions = test_single_tag_data[\n",
+    "    ((pd.notnull(test_single_tag_data['Grants'])) |\n",
+    "     (pd.notnull(test_single_tag_data['Prodigy only'])))]\n",
+    "y_pred = source_additions['Ensemble prediction'].tolist()\n",
+    "y = source_additions['Final tech'].tolist()\n",
+    "\n",
+    "y_tech_index = [i for i, v in enumerate(y) if v==1] # Which grant index were tech\n",
+    "y_pred_tech = [y_pred[i] for i in y_tech_index] # The grant predictions for the tech grants only\n",
+    "\n",
+    "print({'precision': round(precision_score(y, y_pred, average='binary'),3),\n",
+    "     'recall': round(recall_score(y, y_pred, average='binary'),3),\n",
+    "     'f1': round(f1_score(y, y_pred, average='binary'),3),\n",
+    "       'Number tagged': len(y),\n",
+    "       'Number tagged as tech': len(y_tech_index),\n",
+    "       'Proportion predicted as tech were tech': round(sum(y_pred_tech)/len(y_tech_index),3)\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 113,
+   "id": "deluxe-wonder",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'precision': 0.849, 'recall': 0.811, 'f1': 0.829, 'Number tagged': 241, 'Number tagged as tech': 132, 'Proportion predicted as tech were tech': 0.811}\n"
+     ]
+    }
+   ],
+   "source": [
+    "## All data\n",
+    "source_additions = test_single_tag_data\n",
+    "y_pred = source_additions['Ensemble prediction'].tolist()\n",
+    "y = source_additions['Final tech'].tolist()\n",
+    "\n",
+    "y_tech_index = [i for i, v in enumerate(y) if v==1] # Which grant index were tech\n",
+    "y_pred_tech = [y_pred[i] for i in y_tech_index] # The grant predictions for the tech grants only\n",
+    "\n",
+    "print({'precision': round(precision_score(y, y_pred, average='binary'),3),\n",
+    "     'recall': round(recall_score(y, y_pred, average='binary'),3),\n",
+    "     'f1': round(f1_score(y, y_pred, average='binary'),3),\n",
+    "       'Number tagged': len(y),\n",
+    "       'Number tagged as tech': len(y_tech_index),\n",
+    "       'Proportion predicted as tech were tech': round(sum(y_pred_tech)/len(y_tech_index),3)\n",
+    "    })"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "after-perspective",
+   "metadata": {},
+   "source": [
+    "## Output training data with just grants tagged data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 130,
+   "id": "promotional-convert",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "190"
+      ]
+     },
+     "execution_count": 130,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Grant numbers of epmc or rf tagged only\n",
+    "epmc_rf_addition_grants = training_data_details_df[\n",
+    "    pd.isnull(training_data_details_df[['Grants', 'Prodigy only']]).sum(axis=1)==2\n",
+    "]['Grant number'].tolist()\n",
+    "len(epmc_rf_addition_grants)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 133,
+   "id": "guided-galaxy",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "991\n"
+     ]
+    }
+   ],
+   "source": [
+    "new_training_data = []\n",
+    "with open(prodigy_data_dir, 'r') as json_file:\n",
+    "    for json_str in list(json_file):\n",
+    "        data = json.loads(json_str)\n",
+    "        if data['id'] not in epmc_rf_addition_grants:\n",
+    "            new_training_data.append(data)\n",
+    "print(len(new_training_data))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 136,
+   "id": "confident-mills",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open('../data/prodigy/merged_tech_grants/merged_tech_grants_noepmcrf.jsonl', 'w') as json_file:\n",
+    "    for entry in new_training_data:\n",
+    "        json.dump(entry, json_file)\n",
+    "        json_file.write('\\n')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "crucial-region",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
The training data is composed of grants identified as 'tech' from 3 sources:
- EPMC
- researchfish
- the grant descriptions themselves

In this PR I have a look at this data, how much of it there is and how well the model does on the test data split by these 3 sources.

The document summarises all the findings in the notebook.

I also experiment with running the models without the EPMC and RF data contributions - to find that the models improve (despite much less training data).
