### PR TITLE
Refactor creating training data

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,24 @@ The code for this project is in the `nutrition_labels` and `notebooks` folder. M
 - [Tech_grant_model_fairness.md](docs/Tech_grant_model_fairness.md)
 - [Tech_grant_clusters.md](docs/Tech_grant_clusters.md)
 
+### Creating training data
+
+In [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md) we describe the first stage of tagging data to create the training data - this was last updated on the 7th August 2020. In 2021 we updated the definition of 'tech' as described in [Expanding_tech_grants.md](docs/Expanding_tech_grants.md) - this created a new training data set on 26th January 2021. Then, we decided to use active learning in Prodigy to tag more training data, this process is described in [Prodigy_training_data.md](docs/Prodigy_training_data.md), this resulted in a training data set on the 21st February 2021.
+
+Finally, we found that adding grants tagged via EPMC and ResearchFish actually may decrease the model scores, so we created some training data not containing these data points - this was done on 8th March 2021.
+
+| Tag code | Meaning | Number of grants - 200807 | Number of grants - 210126 | Number of grants - 210221 | Number of grants - 210308|
+|---|---|--- |--- | --- | --- |
+| 1 | Relevant | 214 |347 | 495 | 313 |
+| 0 | Not relevant | 883 |349 | 485 | 488 |
+
+To create these datasets you should run:
+```
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.ini
+```
+with config files from '2020.08.07.ini', '2021.01.26.ini', '2021.02.21.ini' or 2021.03.08.ini'.
+
+
 ### Training a tech tagging model
 
 You can train and save a model to classify grants as being to do with tech or not (see definitions for this in [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md)) by running:

--- a/configs/training_data/2021.02.21.ini
+++ b/configs/training_data/2021.02.21.ini
@@ -1,0 +1,17 @@
+[DEFAULT]
+version = 2021.02.21
+description = Creating the training data with tech definition being world-wide and not just in the health domain. Prodigy tags included. This config file is for create_training_data.py.
+
+[data]
+epmc_tags_query_one_filedir = data/raw/expanded_tags/EPMC_relevant_tool_pubs_3082020.csv
+epmc_tags_query_two_filedir = data/raw/expanded_tags/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
+rf_tags_filedir = data/raw/expanded_tags/research_fish_manual_edit.csv
+grant_tags_filedir = data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
+prodigy_filedir = data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
+grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv
+
+[data_col_ranking]
+epmc_col_ranking = ['Revised code']
+grants_col_ranking = ['Revised code']
+

--- a/configs/training_data/2021.03.08.ini
+++ b/configs/training_data/2021.03.08.ini
@@ -1,0 +1,18 @@
+[DEFAULT]
+version = 2021.03.08
+description = Creating the training data with tech definition being world-wide and not just in the health domain. Prodigy tags included, but don't include research fish or EPMC data points. This config file is for create_training_data.py.
+
+[data]
+epmc_tags_query_one_filedir = data/raw/expanded_tags/EPMC_relevant_tool_pubs_3082020.csv
+epmc_tags_query_two_filedir = data/raw/expanded_tags/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
+rf_tags_filedir = data/raw/expanded_tags/research_fish_manual_edit.csv
+grant_tags_filedir = data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
+prodigy_filedir = data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
+grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv
+sources_include = ['Prodigy grants', 'Grants']
+
+[data_col_ranking]
+epmc_col_ranking = ['Revised code']
+grants_col_ranking = ['Revised code']
+

--- a/nutrition_labels/create_training_data.py
+++ b/nutrition_labels/create_training_data.py
@@ -1,0 +1,205 @@
+"""
+Combine different sources of tagged data to create a training set.
+
+Usage
+----------
+python nutrition_labels/create_training_data.py 
+    --config_path configs/training_data/2021.03.08.ini
+
+Description
+----------
+
+Create training data from any combination of 4 sources
+- RF: Tech found from the researchfish data
+- EPMC: Tech found from the researchfish data
+- Grants: Tech or not tech found from the grants descriptions
+- Prodigy grants : Same as above but using Prodigy active learning
+
+Which of these sources to include is defined in the sources_include config parameter.
+
+The pipeline for tagging training data was as follows:
+
+Tag EPMC, tag ResearchFish, tag grants -> Merge together -> Input into Prodigy ->
+    Tag other grants using active learning -> All Progidy input and output merged into one
+
+Thus it's not super clear which are the grants tagged in Prodigy without looking
+at the input. So even if you don't want to include certain data sources in the training
+data, you still need to input them all to distinguish which ones were tagged in Prodigy.
+
+If no Prodigy data is included (no prodigy_filedir in the config file) then this script
+will still work (so old config files are still compatible).
+
+In this script:
+- Input all tagged data sources - EPMC, RF, Grants, Prodigy grants (optional)
+- Clearly label which data came from which source (EPMC, RF, Grants (not using Prodigy), Prodigy grants)
+- Filter out any sources not wanted
+- Output this as the training data
+
+"""
+
+from argparse import ArgumentParser
+import configparser
+import os
+from datetime import datetime
+import json
+import ast
+
+import pandas as pd
+import numpy as np
+
+from nutrition_labels.grant_data_processing import (
+    load_process_data_sources,
+    merge_grants_sources,
+    clean_grants_data,
+    deduplicate_similar_grants,
+)
+from nutrition_labels.prodigy_training_data import load_prodigy_tags
+
+SOURCES = ["RF", "EPMC", "Grants", "Prodigy grants"]
+
+
+def output_counts(training_data):
+
+    print("Number of training data points from the various sources:")
+    multi_tag_data = training_data[pd.notnull(training_data[SOURCES]).sum(axis=1) != 1]
+    print(f"Multiple sources: {len(multi_tag_data)}")
+    single_tag_data = training_data[pd.notnull(training_data[SOURCES]).sum(axis=1) == 1]
+    num_source = pd.notnull(single_tag_data[SOURCES]).sum(axis=0)
+    print(f"Individual sources: \n{num_source}")
+
+
+def combine_original_prodigy(training_data_original, prodigy_output):
+    """
+    Combine the original training data using EPMC, RF and grants
+    with the data tagged in Prodigy, in a format which makes it clear
+    which data point came from each source
+    """
+
+    training_data_original_dict = {}
+    for i, row in training_data_original.iterrows():
+        training_data_original_dict[row["Internal ID"]] = {
+            "Original tag": row["Relevance code"],
+            "RF": None if pd.isnull(row["Normalised code - RF"]) else 1,
+            "EPMC": None if pd.isnull(row["Normalised code - EPMC"]) else 1,
+            "Grants": None
+            if pd.isnull(row["Normalised code - grants"])
+            else (0 if int(row["Normalised code - grants"]) == 5 else 1),
+            "Prodigy grants": None,
+        }
+
+    # Add Prodigy tags to original tags
+    for grant_number, tech_cat in prodigy_output.items():
+        # Add this grant number if not in the original data
+        if not training_data_original_dict.get(grant_number):
+            training_data_original_dict[grant_number] = {
+                "Original tag": None,
+                "RF": None,
+                "EPMC": None,
+                "Grants": None,
+                "Prodigy grants": tech_cat,
+            }
+
+    training_data = pd.DataFrame(training_data_original_dict).T
+    training_data["Internal ID"] = training_data.index
+
+    return training_data
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        "--config_path",
+        help="Path to config file",
+        default="configs/training_data/2021.03.08.ini",
+    )
+
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser()
+    config.read(args.config_path)
+
+    # Load Prodigy data
+    use_prodigy_directly = False
+    if config["data"].get("prodigy_filedir"):
+        prodigy_data = load_prodigy_tags(config["data"]["prodigy_filedir"])
+        prodigy_output = {
+            tag["Internal ID"]: tag["Relevance code"] for tag in prodigy_data
+        }
+        # Depending on the config file parameters, in some cases we can use the
+        # Prodigy output directly for the training data
+        if not config["data"].get("sources_include") or set(
+            ast.literal_eval(config["data"]["sources_include"])
+            ) == set(SOURCES):
+            use_prodigy_directly = True
+    else:
+        prodigy_output = {}
+
+    # Create training data
+    if use_prodigy_directly:
+        training_data = pd.DataFrame(
+            list(prodigy_output.items()), columns=["Internal ID", "Relevance code"]
+        )
+        training_data.drop_duplicates(subset=["Internal ID"], inplace=True)
+        training_data.reset_index()
+    else:
+        if not config["data"].get("sources_include"):
+            sources_include = ["EPMC", "RF", "Grants"]
+        else:
+            sources_include = ast.literal_eval(config["data"]["sources_include"])
+
+        if not set(sources_include).issubset(SOURCES):
+            raise ValueError(
+                f"The list sources_include in {args.config_path} needs to be a subset of {SOURCES}"
+            )
+
+        epmc_df, rf_df, grants_df = load_process_data_sources(
+            config["data"]["epmc_tags_query_one_filedir"],
+            config["data"]["epmc_tags_query_two_filedir"],
+            config["data"]["rf_tags_filedir"],
+            config["data"]["grant_tags_filedir"],
+            ast.literal_eval(config["data_col_ranking"]["epmc_col_ranking"]),
+            ast.literal_eval(config["data_col_ranking"]["grants_col_ranking"]),
+            config["data"]["epmc_pmid2grants_dir"],
+        )
+        grant_data = pd.read_csv(config["data"]["grant_data_filedir"])
+        grant_data = clean_grants_data(grant_data)
+
+        # Training data without Prodigy
+        training_data_original = merge_grants_sources(
+            grant_data, epmc_df, rf_df, grants_df
+        )
+
+        # Combine with the Prodigy data (if any)
+        training_data = combine_original_prodigy(training_data_original, prodigy_output)
+
+        # Only include data with tags from the sources to include list
+        training_data.dropna(subset=sources_include, how="all", inplace=True)
+
+        # Get the tags for these from the columns in sources_include
+        training_data["Relevance code"] = np.nan
+        for source in sources_include:
+            training_data["Relevance code"] = training_data["Relevance code"].fillna(
+                training_data[source]
+            )
+
+        training_data = pd.merge(
+            training_data, grant_data, how="left", on="Internal ID"
+        )
+        training_data = deduplicate_similar_grants(training_data)
+
+        output_counts(training_data)
+
+        training_data = training_data[["Internal ID", "Relevance code"]]
+
+    print(f"Number tagged as 0: {sum(training_data['Relevance code']==0)}")
+    print(f"Number tagged as 1: {sum(training_data['Relevance code']==1)}")
+
+    # Output the data to a dated folder using the config version date
+    # but convert this from 2020.08.07 -> 200807
+    config_version = ''.join(config['DEFAULT']['version'].split('.'))[2:]
+    output_path = os.path.join('data/processed/training_data', config_version)
+    if not os.path.exists(output_path):
+        os.mkdir(output_path)
+    training_data.to_csv(os.path.join(output_path, 'training_data.csv'), index = False)
+

--- a/nutrition_labels/create_training_data.py
+++ b/nutrition_labels/create_training_data.py
@@ -38,9 +38,9 @@ In this script:
 """
 
 from argparse import ArgumentParser
+from datetime import datetime
 import configparser
 import os
-from datetime import datetime
 import json
 import ast
 
@@ -75,49 +75,65 @@ def combine_original_prodigy(training_data_original, prodigy_output):
     which data point came from each source
     """
 
-    training_data_original_dict = {}
-    for i, row in training_data_original.iterrows():
-        training_data_original_dict[row["Internal ID"]] = {
-            "Original tag": row["Relevance code"],
-            "RF": None if pd.isnull(row["Normalised code - RF"]) else 1,
-            "EPMC": None if pd.isnull(row["Normalised code - EPMC"]) else 1,
-            "Grants": None
-            if pd.isnull(row["Normalised code - grants"])
-            else (0 if int(row["Normalised code - grants"]) == 5 else 1),
-            "Prodigy grants": None,
-        }
+    original_data = pd.DataFrame(training_data_original.copy())
+    original_data.drop_duplicates(subset="Internal ID", inplace=True)
+    original_data.rename({"Relevance code": "Original tag"}, axis=1, inplace=True)
+    original_data["RF"] = original_data["Normalised code - RF"].apply(
+        lambda x: None if pd.isnull(x) else 1
+    )
+    original_data["EPMC"] = original_data["Normalised code - EPMC"].apply(
+        lambda x: None if pd.isnull(x) else 1
+    )
+    original_data["Grants"] = original_data["Normalised code - grants"].apply(
+        lambda x: None if pd.isnull(x) else (0 if int(x) == 5 else 1)
+    )
 
-    # Add Prodigy tags to original tags
-    for grant_number, tech_cat in prodigy_output.items():
-        # Add this grant number if not in the original data
-        if not training_data_original_dict.get(grant_number):
-            training_data_original_dict[grant_number] = {
-                "Original tag": None,
-                "RF": None,
-                "EPMC": None,
-                "Grants": None,
-                "Prodigy grants": tech_cat,
-            }
+    prodigy_data = pd.DataFrame.from_dict(
+        prodigy_output, orient="index", columns=["Prodigy grants"]
+    )
+    prodigy_data["Internal ID"] = prodigy_data.index
 
-    training_data = pd.DataFrame(training_data_original_dict).T
-    training_data["Internal ID"] = training_data.index
+    training_data = pd.merge(original_data, prodigy_data, how="outer", on="Internal ID")
+
+    # If in original then set Prodigy grants to nan
+    training_data.loc[
+        pd.notnull(training_data["Original tag"]), "Prodigy grants"
+    ] = np.nan
+
+    return training_data[
+        ["Internal ID", "Original tag", "RF", "EPMC", "Grants", "Prodigy grants"]
+    ]
+
+
+def process_filter_data_sources(
+    grant_data, epmc_df, rf_df, grants_df, prodigy_output, sources_include
+):
+
+    grant_data = clean_grants_data(grant_data)
+
+    # Training data without Prodigy
+    training_data_original = merge_grants_sources(grant_data, epmc_df, rf_df, grants_df)
+
+    # Combine with the Prodigy data (if any)
+    training_data = combine_original_prodigy(training_data_original, prodigy_output)
+
+    # Only include data with tags from the sources to include list
+    training_data.dropna(subset=sources_include, how="all", inplace=True)
+
+    # Get the tags for these from the columns in sources_include
+    training_data["Relevance code"] = np.nan
+    for source in sources_include:
+        training_data["Relevance code"] = training_data["Relevance code"].fillna(
+            training_data[source]
+        )
+
+    training_data = pd.merge(training_data, grant_data, how="left", on="Internal ID")
+    training_data = deduplicate_similar_grants(training_data)
 
     return training_data
 
 
-if __name__ == "__main__":
-    parser = ArgumentParser()
-
-    parser.add_argument(
-        "--config_path",
-        help="Path to config file",
-        default="configs/training_data/2021.03.08.ini",
-    )
-
-    args = parser.parse_args()
-
-    config = configparser.ConfigParser()
-    config.read(args.config_path)
+def create_training_data(config):
 
     # Load Prodigy data
     use_prodigy_directly = False
@@ -130,7 +146,7 @@ if __name__ == "__main__":
         # Prodigy output directly for the training data
         if not config["data"].get("sources_include") or set(
             ast.literal_eval(config["data"]["sources_include"])
-            ) == set(SOURCES):
+        ) == set(SOURCES):
             use_prodigy_directly = True
     else:
         prodigy_output = {}
@@ -153,6 +169,7 @@ if __name__ == "__main__":
                 f"The list sources_include in {args.config_path} needs to be a subset of {SOURCES}"
             )
 
+        # Load datasets
         epmc_df, rf_df, grants_df = load_process_data_sources(
             config["data"]["epmc_tags_query_one_filedir"],
             config["data"]["epmc_tags_query_two_filedir"],
@@ -163,33 +180,12 @@ if __name__ == "__main__":
             config["data"]["epmc_pmid2grants_dir"],
         )
         grant_data = pd.read_csv(config["data"]["grant_data_filedir"])
-        grant_data = clean_grants_data(grant_data)
 
-        # Training data without Prodigy
-        training_data_original = merge_grants_sources(
-            grant_data, epmc_df, rf_df, grants_df
+        # Process datasets - combine, remove sources
+        training_data = process_filter_data_sources(
+            grant_data, epmc_df, rf_df, grants_df, prodigy_output, sources_include
         )
-
-        # Combine with the Prodigy data (if any)
-        training_data = combine_original_prodigy(training_data_original, prodigy_output)
-
-        # Only include data with tags from the sources to include list
-        training_data.dropna(subset=sources_include, how="all", inplace=True)
-
-        # Get the tags for these from the columns in sources_include
-        training_data["Relevance code"] = np.nan
-        for source in sources_include:
-            training_data["Relevance code"] = training_data["Relevance code"].fillna(
-                training_data[source]
-            )
-
-        training_data = pd.merge(
-            training_data, grant_data, how="left", on="Internal ID"
-        )
-        training_data = deduplicate_similar_grants(training_data)
-
         output_counts(training_data)
-
         training_data = training_data[["Internal ID", "Relevance code"]]
 
     print(f"Number tagged as 0: {sum(training_data['Relevance code']==0)}")
@@ -197,9 +193,25 @@ if __name__ == "__main__":
 
     # Output the data to a dated folder using the config version date
     # but convert this from 2020.08.07 -> 200807
-    config_version = ''.join(config['DEFAULT']['version'].split('.'))[2:]
-    output_path = os.path.join('data/processed/training_data', config_version)
+    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
+    output_path = os.path.join("data/processed/training_data", config_version)
     if not os.path.exists(output_path):
         os.mkdir(output_path)
-    training_data.to_csv(os.path.join(output_path, 'training_data.csv'), index = False)
+    training_data.to_csv(os.path.join(output_path, "training_data.csv"), index=False)
 
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        "--config_path",
+        help="Path to config file",
+        default="configs/training_data/2021.03.08.ini",
+    )
+
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser()
+    config.read(args.config_path)
+
+    create_training_data(config)

--- a/nutrition_labels/grant_data_processing.py
+++ b/nutrition_labels/grant_data_processing.py
@@ -10,11 +10,12 @@ import numpy as np
 
 from nutrition_labels.useful_functions import remove_useless_string, only_text
 
+
 def merge_tags(data, person_cols_list):
     # person_cols_list: A list of the column names of people tagging
     #                       in order of preference.
     # e.g. If person [0] and person [1] have labelled the same row then use person [0]'s label
-    data = data.dropna(subset=person_cols_list, how='all').reset_index(drop=True)
+    data = data.dropna(subset=person_cols_list, how="all").reset_index(drop=True)
 
     merged_codes = []
     for _, row in data.iterrows():
@@ -23,169 +24,221 @@ def merge_tags(data, person_cols_list):
                 merged_codes.append(row[person_col])
                 break
 
-    data['Merged code'] = merged_codes
-    
+    data["Merged code"] = merged_codes
+
     return data
 
-def clean_grants_data(old_grant_data, text_column='Description', grant_id_column='Internal ID'):
+
+def clean_grants_data(
+    old_grant_data, text_column="Description", grant_id_column="Internal ID"
+):
     """
     Clean grant descriptions of html and remove any duplicates
     """
     grant_data = old_grant_data.copy()
     grant_data[text_column] = grant_data[text_column].apply(remove_useless_string)
-    grant_data = grant_data[grant_data[text_column] != 'Not available']
+    grant_data = grant_data[grant_data[text_column] != "Not available"]
     grant_data.dropna(subset=[text_column], inplace=True)
     grant_data.drop_duplicates(grant_id_column, inplace=True)
-    grant_data['Internal ID 6 digit'] = grant_data[grant_id_column].apply(lambda x: re.sub('/.*','',x))
+    grant_data["Internal ID 6 digit"] = grant_data[grant_id_column].apply(
+        lambda x: re.sub("/.*", "", x)
+    )
 
     # After dropping rows you need to reset the index
     grant_data.reset_index(inplace=True)
     return grant_data
 
-def process_epmc(epmc_tags_query_one, epmc_tags_query_two, epmc_code_dict, col_ranking_list, pmid2grants):
+
+def process_epmc(
+    epmc_tags_query_one,
+    epmc_tags_query_two,
+    epmc_code_dict,
+    col_ranking_list,
+    pmid2grants,
+):
 
     # Merge EPMC data and normalise the codes
     # Order of truth (if same row has been labelled): Becky > Nonie > Liz > Aoife
     epmc_tags = pd.concat([epmc_tags_query_one, epmc_tags_query_two], ignore_index=True)
     epmc_tags = merge_tags(epmc_tags, col_ranking_list)
-    epmc_tags['Normalised code'] = [epmc_code_dict[str(int(code))] for code in epmc_tags['Merged code']]
+    epmc_tags["Normalised code"] = [
+        epmc_code_dict[str(int(code))] for code in epmc_tags["Merged code"]
+    ]
 
     # No need to include tags if no grant number is given or you don't want to include
     # the grant in the training data
-    epmc_tags.dropna(subset=['WTgrants', 'Normalised code'], inplace=True)
+    epmc_tags.dropna(subset=["WTgrants", "Normalised code"], inplace=True)
 
     # Create list of dicts for each WT grant number given
     epmc_list = []
     for i, row in epmc_tags.iterrows():
-        pmid = str(row['pmid']) # Can sometimes be int
+        pmid = str(row["pmid"])  # Can sometimes be int
         grants = pmid2grants.get(pmid)
         for grant in grants:
-            epmc_list.append({'pmid': pmid,
-                              'Normalised code - EPMC': int(row['Normalised code']),
-                              'Internal ID 6 digit': grant,})
+            epmc_list.append(
+                {
+                    "pmid": pmid,
+                    "Normalised code - EPMC": int(row["Normalised code"]),
+                    "Internal ID 6 digit": grant,
+                }
+            )
 
     epmc_df = pd.DataFrame(epmc_list)
-    epmc_df.drop_duplicates(subset=['Internal ID 6 digit', 'Normalised code - EPMC'], inplace=True)
-    
+    epmc_df.drop_duplicates(
+        subset=["Internal ID 6 digit", "Normalised code - EPMC"], inplace=True
+    )
+
     return epmc_df
+
 
 def process_RF(rf_tags, rf_code_dict):
 
-    rf_tags.dropna(subset=['code '], inplace=True)
-    rf_tags['Normalised code'] = [rf_code_dict[str(int(code))] for code in rf_tags['code ']]
+    rf_tags.dropna(subset=["code "], inplace=True)
+    rf_tags["Normalised code"] = [
+        rf_code_dict[str(int(code))] for code in rf_tags["code "]
+    ]
 
     # No need to include tags if no grant number is given or you don't want to include
     # the grant in the training data
-    rf_tags.dropna(subset=['Grant Reference', 'Normalised code'], inplace=True)
+    rf_tags.dropna(subset=["Grant Reference", "Normalised code"], inplace=True)
 
     # Create list of dicts for each WT grant number given
     rf_list = []
     for i, row in rf_tags.iterrows():
         # Strip whitespace from grant ref, since sometimes it has it
-        rf_list.append({
-            'RF question':row['file'],
-            'RF Name':row['Name'],
-            'Normalised code - RF':int(row['Normalised code']),
-            'Internal ID':row['Grant Reference'].strip(),
-            })
+        rf_list.append(
+            {
+                "RF question": row["file"],
+                "RF Name": row["Name"],
+                "Normalised code - RF": int(row["Normalised code"]),
+                "Internal ID": row["Grant Reference"].strip(),
+            }
+        )
 
     rf_df = pd.DataFrame(rf_list)
-    rf_df.drop_duplicates(subset=['Internal ID', 'Normalised code - RF'], inplace=True)
+    rf_df.drop_duplicates(subset=["Internal ID", "Normalised code - RF"], inplace=True)
 
     return rf_df
+
 
 def process_grants(grant_tags, grants_code_dict, col_ranking_list):
 
     # If Nonie and Liz have labelled it use Nonies
     grant_tags = merge_tags(grant_tags, col_ranking_list)
-    grant_tags['Normalised code'] = [grants_code_dict[str(int(code))] for code in grant_tags['Merged code']]
+    grant_tags["Normalised code"] = [
+        grants_code_dict[str(int(code))] for code in grant_tags["Merged code"]
+    ]
 
     # No need to include tags if you don't want to include
     # the grant in the training data
-    grant_tags.dropna(subset=['Normalised code'], inplace=True)
+    grant_tags.dropna(subset=["Normalised code"], inplace=True)
 
     # Create list of dicts for each WT grant number given
     grants_list = []
     for i, row in grant_tags.iterrows():
         # Strip whitespace from grant ref, since sometimes it has it
-        grants_list.append({
-            'Normalised code - grants':int(row['Normalised code']),
-            'Internal ID':row['Internal ID'],
-            })
+        grants_list.append(
+            {
+                "Normalised code - grants": int(row["Normalised code"]),
+                "Internal ID": row["Internal ID"],
+            }
+        )
     grants_df = pd.DataFrame(grants_list)
-    grants_df.drop_duplicates(subset=['Internal ID', 'Normalised code - grants'], inplace=True)
+    grants_df.drop_duplicates(
+        subset=["Internal ID", "Normalised code - grants"], inplace=True
+    )
 
     return grants_df
 
+
 def load_process_data_sources(
-        epmc_tags_query_one_filedir,
-        epmc_tags_query_two_filedir,
-        rf_tags_filedir,
-        grant_tags_filedir,
+    epmc_tags_query_one_filedir,
+    epmc_tags_query_two_filedir,
+    rf_tags_filedir,
+    grant_tags_filedir,
+    epmc_col_ranking,
+    grants_col_ranking,
+    epmc_pmid2grants_dir,
+):
+    """
+    Load data from EPMC, RF and grants tags.
+    Process each of these datasets into the form needed for merging together.
+    Return processed versions of the  EPMC, RF and grants tags data.
+    """
+
+    epmc_tags_query_one = pd.read_csv(epmc_tags_query_one_filedir, encoding="latin")
+    epmc_tags_query_two = pd.read_csv(epmc_tags_query_two_filedir)
+    rf_tags = pd.read_csv(rf_tags_filedir)
+    grant_tags = pd.read_csv(grant_tags_filedir)
+
+    # Normalising the codes so they are all similar for different data sources
+    # 'None' if you dont want to include these tags in the training data
+    epmc_code_dict = {"1": 1, "2": 2, "3": 3, "4": None, "5": None, "6": None}
+    rf_code_dict = {"1": 1, "2": 2, "3": 3, "4": None, "5": None}
+    grants_code_dict = {"1": 1, "4": None, "5": 5}
+
+    # Load pmid2grants dict for EPMC data
+    with open(epmc_pmid2grants_dir) as f:
+        pmid2grants = json.load(f)
+
+    # Process each of the 3 data sources separately and output a
+    # dataframe for each of grant numbers - cleaned tags links
+    epmc_df = process_epmc(
+        epmc_tags_query_one,
+        epmc_tags_query_two,
+        epmc_code_dict,
         epmc_col_ranking,
-        grants_col_ranking,
-        epmc_pmid2grants_dir):
-        """
-        Load data from EPMC, RF and grants tags.
-        Process each of these datasets into the form needed for merging together.
-        Return processed versions of the  EPMC, RF and grants tags data.
-        """
+        pmid2grants,
+    )
+    rf_df = process_RF(rf_tags, rf_code_dict)
+    grants_df = process_grants(grant_tags, grants_code_dict, grants_col_ranking)
 
-        epmc_tags_query_one = pd.read_csv(epmc_tags_query_one_filedir, encoding = "latin")
-        epmc_tags_query_two = pd.read_csv(epmc_tags_query_two_filedir)
-        rf_tags = pd.read_csv(rf_tags_filedir)
-        grant_tags = pd.read_csv(grant_tags_filedir)
+    return epmc_df, rf_df, grants_df
 
-        # Normalising the codes so they are all similar for different data sources
-        # 'None' if you dont want to include these tags in the training data
-        epmc_code_dict = {'1': 1, '2': 2, '3': 3, '4': None, '5': None, '6': None}
-        rf_code_dict = {'1': 1, '2': 2, '3': 3, '4': None, '5': None}
-        grants_code_dict = {'1': 1, '4': None, '5': 5}
-
-        # Load pmid2grants dict for EPMC data
-        with open(epmc_pmid2grants_dir) as f:
-            pmid2grants = json.load(f)
-
-        # Process each of the 3 data sources separately and output a 
-        # dataframe for each of grant numbers - cleaned tags links
-        epmc_df = process_epmc(
-            epmc_tags_query_one,
-            epmc_tags_query_two,
-            epmc_code_dict,
-            epmc_col_ranking,
-            pmid2grants
-            )
-        rf_df = process_RF(rf_tags, rf_code_dict)
-        grants_df = process_grants(grant_tags, grants_code_dict, grants_col_ranking)
-
-        return epmc_df, rf_df, grants_df
 
 def merge_grants_sources(grant_data, epmc_df, rf_df, grants_df, print_out=False):
 
     # Link with RF data (which uses 13 digit)
-    grant_data = pd.merge(grant_data, rf_df, how = 'left', on = 'Internal ID')
+    grant_data = pd.merge(grant_data, rf_df, how="left", on="Internal ID")
     # Link with grant data (which uses 13 digit)
-    grant_data = pd.merge(grant_data, grants_df, how = 'left', on = 'Internal ID')
+    grant_data = pd.merge(grant_data, grants_df, how="left", on="Internal ID")
 
     # Order grants by 1. those that have tags from RF or grants,
     # 2. if they havent been tagged yet, those with the most recent award date should go higher up
-    grant_data.sort_values(by=['Normalised code - RF', 'Normalised code - grants', 'Award Date'], ascending=False, inplace=True)
+    grant_data.sort_values(
+        by=["Normalised code - RF", "Normalised code - grants", "Award Date"],
+        ascending=False,
+        inplace=True,
+    )
 
     # Link with EPMC data (which uses 6 digit)
-    grant_data = pd.merge(grant_data, epmc_df, how = 'left', on = 'Internal ID 6 digit')
+    grant_data = pd.merge(grant_data, epmc_df, how="left", on="Internal ID 6 digit")
 
     if print_out:
-        print("Grants flagged as relevant in EPMC publications not found in grants data: ")
-        print(set(epmc_df['Internal ID 6 digit']).difference(set(grant_data['Internal ID 6 digit'])))
-        print("PMIDs flagged as relevant in Wellcome EPMC publications but not found to link to any grants in the grants data: ")
-        print(set(epmc_df['pmid']).difference(set(grant_data['pmid'])))
+        print(
+            "Grants flagged as relevant in EPMC publications not found in grants data: "
+        )
+        print(
+            set(epmc_df["Internal ID 6 digit"]).difference(
+                set(grant_data["Internal ID 6 digit"])
+            )
+        )
+        print(
+            "PMIDs flagged as relevant in Wellcome EPMC publications but not found to link to any grants in the grants data: "
+        )
+        print(set(epmc_df["pmid"]).difference(set(grant_data["pmid"])))
         print("Grants flagged as relevant in RF data not found in grants data: ")
-        print(set(rf_df['Internal ID']).difference(set(grant_data['Internal ID'])))
+        print(set(rf_df["Internal ID"]).difference(set(grant_data["Internal ID"])))
 
     # Final list
     grant_data = grant_data.dropna(
-        subset=['Normalised code - RF', 'Normalised code - grants', 'Normalised code - EPMC'], 
-        how='all').reset_index(drop=True)
+        subset=[
+            "Normalised code - RF",
+            "Normalised code - grants",
+            "Normalised code - EPMC",
+        ],
+        how="all",
+    ).reset_index(drop=True)
     # Get the final single code for each grant:
     # If there is conflict in tags, the order of truth is:
     # 1. EPMC (this shows solid evidence of the output)
@@ -193,41 +246,44 @@ def merge_grants_sources(grant_data, epmc_df, rf_df, grants_df, print_out=False)
     # 3. Grants (they might not have created the output at the time of the application)
     code = []
     for _, row in grant_data.iterrows():
-        if pd.notnull(row['Normalised code - EPMC']):
-            code.append(row['Normalised code - EPMC'])
-        elif pd.notnull(row['Normalised code - RF']):
-            code.append(row['Normalised code - RF'])
-        elif pd.notnull(row['Normalised code - grants']):
-            code.append(row['Normalised code - grants'])
+        if pd.notnull(row["Normalised code - EPMC"]):
+            code.append(row["Normalised code - EPMC"])
+        elif pd.notnull(row["Normalised code - RF"]):
+            code.append(row["Normalised code - RF"])
+        elif pd.notnull(row["Normalised code - grants"]):
+            code.append(row["Normalised code - grants"])
         else:
-            print('Should have deduplicated this row?')
+            print("Should have deduplicated this row?")
 
     # Map the final codes onto whether the grant is 'relevant' (1) or not (0)
-    relevance_dict = {1:1, 2:1, 3:1, 5:0}
-    grant_data['Relevance code'] = [relevance_dict[int(c)] for c in code]
+    relevance_dict = {1: 1, 2: 1, 3: 1, 5: 0}
+    grant_data["Relevance code"] = [relevance_dict[int(c)] for c in code]
 
     return grant_data
 
-def deduplicate_similar_grants(grant_data, text_column='Description', grant_id_column='Internal ID 6 digit'):
+
+def deduplicate_similar_grants(
+    grant_data, text_column="Description", grant_id_column="Internal ID 6 digit"
+):
     """
     Some descriptions have some spaces deleted. We don't want to include
     grants from the same family (6 digit ID) if they have effectively the same description
     """
     grant_data = grant_data.copy()
-    grant_data['Temporary column'] = grant_data[text_column].str.replace(r'\W','')
-    grant_data = grant_data.drop_duplicates([grant_id_column, 'Temporary column'])
-    grant_data.drop('Temporary column', axis=1, inplace=True)
+    grant_data["Temporary column"] = grant_data[text_column].str.replace(r"\W", "")
+    grant_data = grant_data.drop_duplicates([grant_id_column, "Temporary column"])
+    grant_data.drop("Temporary column", axis=1, inplace=True)
 
     return grant_data
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     parser = ArgumentParser()
     parser.add_argument(
-        '--config_path',
-        help='Path to config file',
-        default='configs/training_data/2021.01.26.ini'
+        "--config_path",
+        help="Path to config file",
+        default="configs/training_data/2021.01.26.ini",
     )
     args = parser.parse_args()
 
@@ -241,34 +297,47 @@ if __name__ == '__main__':
         config["data"]["grant_tags_filedir"],
         ast.literal_eval(config["data_col_ranking"]["epmc_col_ranking"]),
         ast.literal_eval(config["data_col_ranking"]["grants_col_ranking"]),
-        config["data"]["epmc_pmid2grants_dir"]
-        )
+        config["data"]["epmc_pmid2grants_dir"],
+    )
 
-    print(f'Tagged data to include from EPMC: {len(epmc_df)}')
-    print(f'Tagged data to include from RF: {len(rf_df)}')
-    print(f'Tagged data to include from grant descriptions: {len(grants_df)}')
+    print(f"Tagged data to include from EPMC: {len(epmc_df)}")
+    print(f"Tagged data to include from RF: {len(rf_df)}")
+    print(f"Tagged data to include from grant descriptions: {len(grants_df)}")
 
     grant_data = pd.read_csv(config["data"]["grant_data_filedir"])
     grant_data = clean_grants_data(grant_data)
 
-    grant_data = merge_grants_sources(grant_data, epmc_df, rf_df, grants_df, print_out=True)
+    grant_data = merge_grants_sources(
+        grant_data, epmc_df, rf_df, grants_df, print_out=True
+    )
 
     grant_data = deduplicate_similar_grants(grant_data)
-    # Note: This deduplication is after the general cleaning since it deduplicates on 
+    # Note: This deduplication is after the general cleaning since it deduplicates on
     # 6 digit number, which needs to come after the merging with RF/Grants data
 
-    num_irrelevant = len([i for i in grant_data['Relevance code'] if i==0])
-    print(f'Number tagged as 0: {num_irrelevant}')
-    print(f'Number tagged as 1: {len(grant_data) - num_irrelevant}')
-    grant_data = grant_data[[
-        'Internal ID', 'RF question', 'RF Name', 'pmid', 'Relevance code',
-        'Normalised code - RF', 'Normalised code - grants', 'Normalised code - EPMC',
-        'Description', 'Title', 'Grant Programme:Title']]
+    num_irrelevant = len([i for i in grant_data["Relevance code"] if i == 0])
+    print(f"Number tagged as 0: {num_irrelevant}")
+    print(f"Number tagged as 1: {len(grant_data) - num_irrelevant}")
+    grant_data = grant_data[
+        [
+            "Internal ID",
+            "RF question",
+            "RF Name",
+            "pmid",
+            "Relevance code",
+            "Normalised code - RF",
+            "Normalised code - grants",
+            "Normalised code - EPMC",
+            "Description",
+            "Title",
+            "Grant Programme:Title",
+        ]
+    ]
 
     # Output the data to a dated folder using the config version date
     # but convert this from 2020.08.07 -> 200807
-    config_version = ''.join(config['DEFAULT']['version'].split('.'))[2:]
-    output_path = os.path.join('data/processed/training_data', config_version)    
+    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
+    output_path = os.path.join("data/processed/training_data", config_version)
     if not os.path.exists(output_path):
         os.mkdir(output_path)
-    grant_data.to_csv(os.path.join(output_path, 'training_data.csv'), index = False)
+    grant_data.to_csv(os.path.join(output_path, "training_data.csv"), index=False)

--- a/nutrition_labels/grant_data_processing.py
+++ b/nutrition_labels/grant_data_processing.py
@@ -35,10 +35,11 @@ def clean_grants_data(
     """
     Clean grant descriptions of html and remove any duplicates
     """
+    dont_include_text = ["Not available", ""]
     grant_data = old_grant_data.copy()
-    grant_data[text_column] = grant_data[text_column].apply(remove_useless_string)
-    grant_data = grant_data[grant_data[text_column] != "Not available"]
     grant_data.dropna(subset=[text_column], inplace=True)
+    grant_data[text_column] = grant_data[text_column].apply(remove_useless_string)
+    grant_data = grant_data[~grant_data[text_column].isin(dont_include_text)]
     grant_data.drop_duplicates(grant_id_column, inplace=True)
     grant_data["Internal ID 6 digit"] = grant_data[grant_id_column].apply(
         lambda x: re.sub("/.*", "", x)

--- a/nutrition_labels/prodigy_training_data.py
+++ b/nutrition_labels/prodigy_training_data.py
@@ -10,22 +10,12 @@ import json
 
 import pandas as pd
 
-if __name__ == '__main__':
-    
-    parser = ArgumentParser()
-    parser.add_argument(
-        '--prodigy_data_dir',
-        help='Path to prodigy output dataset file',
-        default='data/prodigy/tech_grants/tech_grants.jsonl'
-    )
-    args = parser.parse_args()
-
-    datestamp = datetime.now().date().strftime('%y%m%d')
+def load_prodigy_tags(prodigy_data_dir):
 
     cat2bin = {'Not tech grant': 0, 'Tech grant': 1}
 
     training_data = []
-    with open(args.prodigy_data_dir, 'r') as json_file:
+    with open(prodigy_data_dir, 'r') as json_file:
         for json_str in list(json_file):
             data = json.loads(json_str)
             if data['answer'] != 'ignore':
@@ -42,6 +32,23 @@ if __name__ == '__main__':
                     annotation['Relevance code'] = abs(label - 1)
                 training_data.append(annotation)
 
+    return training_data
+
+
+if __name__ == '__main__':
+    
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--prodigy_data_dir',
+        help='Path to prodigy output dataset file',
+        default='data/prodigy/tech_grants/tech_grants.jsonl'
+    )
+    args = parser.parse_args()
+
+    datestamp = datetime.now().date().strftime('%y%m%d')
+
+    training_data = load_prodigy_tags(args.prodigy_data_dir)
+
     training_data = pd.DataFrame(training_data)
     training_data.drop_duplicates(subset=['Internal ID'], inplace=True)
     training_data.reset_index()
@@ -51,4 +58,5 @@ if __name__ == '__main__':
     if not os.path.exists(output_path):
         os.mkdir(output_path)
     training_data.to_csv(os.path.join(output_path, 'training_data.csv'), index = False)
-    
+
+ 

--- a/nutrition_labels/prodigy_training_data.py
+++ b/nutrition_labels/prodigy_training_data.py
@@ -10,53 +10,49 @@ import json
 
 import pandas as pd
 
+
 def load_prodigy_tags(prodigy_data_dir):
 
-    cat2bin = {'Not tech grant': 0, 'Tech grant': 1}
+    cat2bin = {"Not tech grant": 0, "Tech grant": 1}
 
     training_data = []
-    with open(prodigy_data_dir, 'r') as json_file:
+    with open(prodigy_data_dir, "r") as json_file:
         for json_str in list(json_file):
             data = json.loads(json_str)
-            if data['answer'] != 'ignore':
-                annotation = {
-                    'Internal ID': data['id'],
-                    'Grant texts': data['text']
-                    }
-                label = cat2bin[data['label']]
-                if data['answer']=='accept':
-                    annotation['Relevance code'] = label
+            if data["answer"] != "ignore":
+                annotation = {"Internal ID": data["id"], "Grant texts": data["text"]}
+                label = cat2bin[data["label"]]
+                if data["answer"] == "accept":
+                    annotation["Relevance code"] = label
                 else:
-                    # If label=1, append 0 
+                    # If label=1, append 0
                     # if label=0, append 1
-                    annotation['Relevance code'] = abs(label - 1)
+                    annotation["Relevance code"] = abs(label - 1)
                 training_data.append(annotation)
 
     return training_data
 
 
-if __name__ == '__main__':
-    
+if __name__ == "__main__":
+
     parser = ArgumentParser()
     parser.add_argument(
-        '--prodigy_data_dir',
-        help='Path to prodigy output dataset file',
-        default='data/prodigy/tech_grants/tech_grants.jsonl'
+        "--prodigy_data_dir",
+        help="Path to prodigy output dataset file",
+        default="data/prodigy/tech_grants/tech_grants.jsonl",
     )
     args = parser.parse_args()
 
-    datestamp = datetime.now().date().strftime('%y%m%d')
+    datestamp = datetime.now().date().strftime("%y%m%d")
 
     training_data = load_prodigy_tags(args.prodigy_data_dir)
 
     training_data = pd.DataFrame(training_data)
-    training_data.drop_duplicates(subset=['Internal ID'], inplace=True)
+    training_data.drop_duplicates(subset=["Internal ID"], inplace=True)
     training_data.reset_index()
 
-    output_path = os.path.join('data/processed/training_data', datestamp)
+    output_path = os.path.join("data/processed/training_data", datestamp)
 
     if not os.path.exists(output_path):
         os.mkdir(output_path)
-    training_data.to_csv(os.path.join(output_path, 'training_data.csv'), index = False)
-
- 
+    training_data.to_csv(os.path.join(output_path, "training_data.csv"), index=False)

--- a/nutrition_labels/useful_functions.py
+++ b/nutrition_labels/useful_functions.py
@@ -13,9 +13,8 @@ def remove_useless_string(string):
 
     soup = BeautifulSoup(string, features="lxml")
     string_out = soup.get_text()
-    string_out = string_out.strip('\n')
-    string_out = string_out.strip('\xa0')
-    string_out = re.sub('  ','',string_out)
+    string_out = string_out.replace('\n', ' ')
+    string_out = string_out.replace('\xa0', ' ')
     return(string_out)
 
 def only_text(string):

--- a/tests/test_training_data.py
+++ b/tests/test_training_data.py
@@ -1,0 +1,198 @@
+import pytest
+import tempfile
+import os
+import json
+
+import pandas as pd
+
+from nutrition_labels.grant_data_processing import (
+    clean_grants_data,
+    merge_grants_sources,
+    deduplicate_similar_grants,
+)
+from nutrition_labels.prodigy_training_data import load_prodigy_tags
+
+uncleaned_grant_data = pd.DataFrame(
+    [
+        {
+            "Description": '<p style="margin-left: 0px; margin-right: 0px"><strong>This</strong> has html.</p><p style="margin-left: 0px; margin-right: 0px">&nbsp;</p><ul style="list-style-type: disc"><li>It includes a list:</li><li>first in list,</li><li>second in list</li></ul>',
+            "Internal ID": "111111/B/19/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": "Grants description about a particular gene.",
+            "Internal ID": "555555/A/20/Z",
+            "Award Date": "02/01/2000",
+        },
+        {
+            "Description": "Grantsdescriptionabout aparticular gene.",
+            "Internal ID": "555555/Z/20/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": "In this grant we hope to create new software",
+            "Internal ID": "987654/A/19/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": "This is a grant about the history of medicine",
+            "Internal ID": "777777/A/19/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": "This is a duplicated grant in the data",
+            "Internal ID": "444444/Z/19/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": "This is a duplicated grant in the data",
+            "Internal ID": "444444/Z/19/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": "Not available",
+            "Internal ID": "123456/A/20/Z",
+            "Award Date": "01/01/2000",
+        },
+        {
+            "Description": None,
+            "Internal ID": "222222/Z/19/Z",
+            "Award Date": "01/01/2000",
+        },
+        {"Description": "", "Internal ID": "333333/Z/19/Z", "Award Date": "01/01/2000"},
+    ]
+)
+
+epmc_df = pd.DataFrame(
+    [
+        {"Internal ID 6 digit": "111111", "Normalised code - EPMC": 2},
+        {"Internal ID 6 digit": "555555", "Normalised code - EPMC": 1},
+    ]
+)
+
+rf_df = pd.DataFrame(
+    [
+        {"Internal ID": "111111/B/19/Z", "Normalised code - RF": 3},
+        {"Internal ID": "987654/A/19/Z", "Normalised code - RF": 1},
+    ]
+)
+
+grants_df = pd.DataFrame(
+    [
+        {"Internal ID": "111111/B/19/Z", "Normalised code - grants": 5},
+        {"Internal ID": "987654/A/19/Z", "Normalised code - grants": 1},
+        {"Internal ID": "777777/A/19/Z", "Normalised code - grants": 5},
+    ]
+)
+
+
+def test_clean_grants_data():
+
+    grant_data = clean_grants_data(uncleaned_grant_data)
+
+    html_grant_text = grant_data.iloc[0]["Description"]
+
+    assert len(grant_data) == 6
+    assert (
+        html_grant_text
+        == "This has html. It includes a list:first in list,second in list"
+    )
+
+
+def test_merge_grants_sources():
+
+    grant_data = clean_grants_data(uncleaned_grant_data)
+
+    merged_grant_data = merge_grants_sources(grant_data, epmc_df, rf_df, grants_df)
+
+    ids_included = [
+        "111111/B/19/Z",
+        "987654/A/19/Z",
+        "777777/A/19/Z",
+        "555555/A/20/Z",
+        "555555/Z/20/Z",
+    ]
+
+    # Check only tagged grant_data was kept in
+    assert set(merged_grant_data["Internal ID"]) == set(ids_included)
+    # Check grant with contradictory EPMC/grants tag was given EPMC tag
+    assert (
+        merged_grant_data.loc[merged_grant_data["Internal ID"] == "111111/B/19/Z"][
+            "Relevance code"
+        ][0]
+        == 1
+    )
+
+
+def test_deduplicate_similar_grants():
+
+    grant_data = pd.DataFrame(
+        [
+            {
+                "Description": "Grants description about a particular gene.",
+                "Internal ID 6 digit": "555555",
+            },
+            {
+                "Description": "Grantsdescriptionabout aparticular gene.",
+                "Internal ID 6 digit": "555555",
+            },
+        ]
+    )
+    grant_data = deduplicate_similar_grants(grant_data)
+
+    assert len(grant_data) == 1
+
+
+def test_load_prodigy_tags():
+
+    prodigy_data = [
+        {
+            "id": "555555/A/20/Z",
+            "text": "Grants description about a particular gene.",
+            "label": "Tech grant",
+            "answer": "ignore",
+        },
+        {
+            "id": "987654/A/19/Z",
+            "text": "In this grant we hope to create new software",
+            "label": "Tech grant",
+            "answer": "accept",
+        },
+        {
+            "id": "777777/A/19/Z",
+            "text": "This is a grant about the history of medicine",
+            "label": "Tech grant",
+            "answer": "reject",
+        },
+        {
+            "id": "777778/A/19/Z",
+            "text": "This is another grant about the history of medicine",
+            "label": "Not tech grant",
+            "answer": "accept",
+        },
+        {
+            "id": "777779/A/19/Z",
+            "text": "This is a tech grant",
+            "label": "Not tech grant",
+            "answer": "reject",
+        },
+    ]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        prodigy_data_dir = os.path.join(tmp_dir, "prodigy_data.jsonl")
+        with open(prodigy_data_dir, "w") as json_file:
+            for entry in prodigy_data:
+                json.dump(entry, json_file)
+                json_file.write("\n")
+        training_data = load_prodigy_tags(prodigy_data_dir)
+
+    correct_labels = {
+        "987654/A/19/Z": 1,
+        "777777/A/19/Z": 0,
+        "777778/A/19/Z": 0,
+        "777779/A/19/Z": 1,
+    }
+    assert len(training_data) == 4
+    assert all(
+        [correct_labels[t["Internal ID"]] == t["Relevance code"] for t in training_data]
+    )


### PR DESCRIPTION
Part of https://github.com/wellcometrust/nutrition-labels/issues/62

https://trello.com/c/Zeqx0bay/1193-tech-model-refactor

Previously creating the training data followed the steps:
1. Tag EMPC, RF, and grants data
2. Merge these into one training data set in `grant_data_processing.py`

Then I added data via Prodigy in January:
3. Use output in `Get prodigy format data.ipynb` to create data for tagging in Prodigy
4. Tag data in Prodigy and output original tags + Prodigy tags in one file
5. Use this output in `prodigy_training_data.py` to create a training data set

Thus in finding out EPMC and RF data may in fact make the model worse if including in the training data (in https://github.com/wellcometrust/nutrition-labels/pull/61), I needed to refactor this convoluted process to easily take this data out.

So in this PR:
- 💄 `grant_data_processing.py` and `prodigy_training_data.py` are mostly nothing new - just rearranged/cleaned-up
- 🐛  Some fixes to how the text data is cleaned has been included in commit https://github.com/wellcometrust/nutrition-labels/pull/63/commits/2af224006dd6622d87d3b37828ff62299f9fcc28 Note: its hard to know the impact of this extra cleaning - but perhaps it should be expected that old models won't be able to be recreated anymore.
- 🎨  The new script `create_training_data.py` can now be used to merge any combination of EMPC, RF, grants and Prodigy grants into one training data set. The old config files will also work with this to create the old training datasets - so `grant_data_processing.py` and `prodigy_training_data.py` are now more like utils function files rather than scripts that need to be run.
- 🚨  Adds tests
