### PR TITLE
Refactoring training models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ dist
 
 # Folders
 **/models/*
+**/model_repeats/*
+**/data/*
+**/docs/*
+**/notebooks/*

--- a/README.md
+++ b/README.md
@@ -60,13 +60,19 @@ with config files from '2020.08.07.ini', '2021.01.26.ini', '2021.02.21.ini' or 2
 
 ### Training a tech tagging model
 
-You can train and save a model to classify grants as being to do with tech or not (see definitions for this in [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md)) by running:
+You can train and save a model, or several models, to classify grants as being to do with tech or not (see definitions for this in [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md)) by creating a config file which contains various training arguments for the experiments. The main arguments in this config file are:
 
-```
-python nutrition_labels/grant_tagger.py --training_data_file data/processed/training_data.csv --vectorizer_type count --relevant_sample_ratio 1 --model_type naive_bayes --bert_type bert
-```
+- `training_data_file`, e.g. `data/processed/training_data/210308/training_data.csv`, the training data file.
+- `vectorizer_types`, e.g. `['count', 'tfidf', 'bert', 'scibert']`, the vectorizers you want to use.
+- `classifier_types`, e.g. `['naive_bayes', 'SVM', 'log_reg']`, the classifier types you want to use.
 
-where `vectorizer_type` can be 'count', 'tfidf' or 'bert', `model_type` can be 'naive_bayes', 'SVM' and 'log_reg', and `bert_type` (if using bert) can be 'bert' and 'scibert'.
+Then by running 
+```
+python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.03.16.ini
+```
+every combination from `vectorizer_types` and `classifier_types` will be run.
+
+This will create a folder in `models/` named after the config version, and each trained model will be stored in their own subfolders. A summary json file with the model predictions will be stored in e.g. `models/210316/training_information.json`, this will be important in evaluating the ensemble model.
 
 ### Fairness
 

--- a/configs/train_model/2021.02.21.ini
+++ b/configs/train_model/2021.02.21.ini
@@ -1,0 +1,20 @@
+[DEFAULT]
+version = 2021.02.21
+description = Train all models with 210221 training data.
+
+[data]
+training_data_file = data/processed/training_data/210221/training_data.csv
+label_name = Relevance code
+training_data_file_id = Internal ID
+prediction_cols = ['Title', 'Grant Programme:Title', 'Description']
+grants_text_data_file = data/raw/wellcome-grants-awarded-2005-2019.csv
+grants_text_data_file_id = Internal ID
+
+[models]
+vectorizer_types = ['count', 'tfidf', 'bert', 'scibert']
+classifier_types = ['naive_bayes', 'SVM', 'log_reg']
+
+[params]
+relevant_sample_ratio = 1
+test_size = 0.25
+split_seed = 1

--- a/configs/train_model/2021.03.16.ini
+++ b/configs/train_model/2021.03.16.ini
@@ -1,0 +1,20 @@
+[DEFAULT]
+version = 2021.03.16
+description = Train all models with 210308 training data.
+
+[data]
+training_data_file = data/processed/training_data/210308/training_data.csv
+label_name = Relevance code
+training_data_file_id = Internal ID
+prediction_cols = ['Title', 'Grant Programme:Title', 'Description']
+grants_text_data_file = data/raw/wellcome-grants-awarded-2005-2019.csv
+grants_text_data_file_id = Internal ID
+
+[models]
+vectorizer_types = ['count', 'tfidf', 'bert', 'scibert']
+classifier_types = ['naive_bayes', 'SVM', 'log_reg']
+
+[params]
+relevant_sample_ratio = 1
+test_size = 0.25
+split_seed = 7

--- a/configs/train_model/2021.03.16.ini
+++ b/configs/train_model/2021.03.16.ini
@@ -17,4 +17,4 @@ classifier_types = ['naive_bayes', 'SVM', 'log_reg']
 [params]
 relevant_sample_ratio = 1
 test_size = 0.25
-split_seed = 7
+split_seed = 1

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -194,7 +194,7 @@ class GrantTagger:
         if self.classifier_type == "naive_bayes":
             model = MultinomialNB()
         elif self.classifier_type == "SVM":
-            model = SVC()
+            model = SVC(probability=True)
         elif self.classifier_type == "log_reg":
             model = LogisticRegression(max_iter=1000)
         else:

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -124,7 +124,7 @@ class GrantTagger:
             )
         self.X_ids = data[train_data_id].tolist()
         self.X = data["Grant texts"].tolist()
-        self.y = data[self.label_name]
+        self.y = data[self.label_name].tolist()
 
         if self.vectorizer_type == "count":
             self.vectorizer = CountVectorizer(
@@ -152,7 +152,6 @@ class GrantTagger:
 
     def split_data(self, X_vect, y):
 
-        y = y.tolist()
         # Randomly shuffle the data
         random_index = list(range(len(y)))
         seed(self.split_seed)

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -1,7 +1,35 @@
+"""
+Usage
+----------
+python nutrition_labels/grant_tagger.py 
+    --config_path configs/train_model/2021.03.16.ini
+
+Description
+----------
+This code will train several models (as specified in the config argument) using the same 
+training data and parameters inputted in the config file. 
+The trained models and their evaluation results, as well as overall training information 
+will be saved in folder unique to the config file e.g 'models/210316/'
+
+Config notes
+----------
+split_seed in the config file can be kept blank "split_seed = "
+In this case the seed is different for every model trained, which means
+the training data will be different for each model and so to evaluate
+an ensemble model properly you will need a hold-out test set which hasn't
+been used in the training of any of the models.
+"""
+
 from sklearn.feature_extraction.text import CountVectorizer, TfidfVectorizer
 from sklearn.naive_bayes import MultinomialNB
 from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, classification_report, f1_score, precision_score, recall_score
+from sklearn.metrics import (
+    accuracy_score,
+    classification_report,
+    f1_score,
+    precision_score,
+    recall_score,
+)
 from wellcomeml.ml.bert_vectorizer import BertVectorizer
 from sklearn.preprocessing import MinMaxScaler
 from sklearn.linear_model import LogisticRegression
@@ -16,65 +44,111 @@ import pickle
 import configparser
 import os
 import ast
+import json
 
 from nutrition_labels.useful_functions import pretty_confusion_matrix
 
 
-class GrantTagger():
+class GrantTagger:
+    """
+    A class to train a binary classifier for grants text.
+    ...
+
+    Attributes
+    ----------
+    test_size : float (default 0.25)
+        Proportion of data to use in test set.
+    relevant_sample_ratio : float (default 1)
+        The ratio of tech (1) data points to not-tech (0) data points
+        to include in the test/train data. The remainder is disgarded.
+        This is not random - if not-tech points need to be disgarded they
+        are selected uniformly through the data.
+    split_seed : int (default 1)
+        The seed used to randomly shuffle the data for the test/train split.
+    vectorizer_type : str (default "count")
+        The vectorizer to use, can be from ['count', 'tfidf', 'bert', 'scibert'] 
+    classifier_type : str (default "naive_bayes")
+        The classifier to use, can be from ['naive_bayes', 'SVM', 'log_reg'] 
+    prediction_cols : list (default ["Title", "Grant Programme:Title", "Description"])
+        The column names for the text you want to train the model on. If len > 1 then
+        they will be merged into one. 
+    label_name : str (default "Relevance code")
+        The column name of the classification truth label.
+
+    Methods
+    -------
+    transform(data, train_data_id)
+        Fit a vectorizer using the text data
+    split_data(X_vect, y)
+        Split the data into train and test sets
+    fit(X, y)
+        Train the model
+    predict(X)
+        Make predictions using the trained model
+    predict_proba(X)
+        Output prediction probabilities using the trained model
+    evaluate(X, y, extra_scores, average)
+        Evaluate various metrics using the model.
+    train_test_info()
+        Create an output dictionary with information about
+        which data points were used in the test or training, and
+        the model predictions for each.
+    save_model(output_path, evaluation_results)
+    load_model(output_path)
+    """
+
     def __init__(
         self,
-        ngram_range=(1,2),
         test_size=0.25,
         relevant_sample_ratio=1,
         split_seed=1,
-        vectorizer_type='count',
-        classifier_type='naive_bayes',
-        prediction_cols=['Title', 'Grant Programme:Title', 'Description'],
-        label_name="Relevance code"
-        ):
-        self.ngram_range = ngram_range
+        vectorizer_type="count",
+        classifier_type="naive_bayes",
+        prediction_cols=["Title", "Grant Programme:Title", "Description"],
+        label_name="Relevance code",
+    ):
         self.test_size = test_size
         self.relevant_sample_ratio = relevant_sample_ratio
         self.split_seed = split_seed
         self.vectorizer_type = vectorizer_type
         self.classifier_type = classifier_type
-        self.prediction_cols = *prediction_cols,
+        self.prediction_cols = (*prediction_cols,)
         self.label_name = label_name
 
-    def transform(self, data):
+    def transform(self, data, train_data_id="Internal ID"):
 
-        if 'Grant texts' not in data:
+        if "Grant texts" not in data:
             # If the training data hasn't come through Prodigy tagging then this won't exist
-            data['Grant texts'] = data[list(self.prediction_cols)].agg(
-                '. '.join, axis=1
-                )
-        self.X = data['Grant texts'].tolist()
-        y = data[self.label_name]
+            data["Grant texts"] = data[list(self.prediction_cols)].agg(
+                ". ".join, axis=1
+            )
+        self.X_ids = data[train_data_id].tolist()
+        self.X = data["Grant texts"].tolist()
+        self.y = data[self.label_name]
 
-        if self.vectorizer_type == 'count':
+        if self.vectorizer_type == "count":
             self.vectorizer = CountVectorizer(
-                analyzer='word',
-                token_pattern=r'(?u)\b\w+\b',
-                ngram_range=self.ngram_range
-                )
-        elif self.vectorizer_type == 'tfidf':
+                analyzer="word",
+                token_pattern=r"(?u)\b\w+\b",
+                ngram_range=(1, 2),
+            )
+        elif self.vectorizer_type == "tfidf":
             self.vectorizer = TfidfVectorizer(
-                analyzer='word',
-                token_pattern=r'(?u)\b\w+\b',
-                ngram_range=self.ngram_range
-                )
-        elif self.vectorizer_type == 'bert':
+                analyzer="word",
+                token_pattern=r"(?u)\b\w+\b",
+                ngram_range=(1, 2),
+            )
+        elif self.vectorizer_type == "bert":
             self.vectorizer = BertVectorizer(pretrained=self.vectorizer_type)
         else:
-            print('Vectorizer type not recognised')
-        X_vect = self.vectorizer.fit_transform(self.X)
+            print("Vectorizer type not recognised")
+        self.X_vect = self.vectorizer.fit_transform(self.X)
 
-        if 'bert' in self.vectorizer_type and self.classifier_type == 'naive_bayes':
+        if "bert" in self.vectorizer_type and self.classifier_type == "naive_bayes":
             scaler = MinMaxScaler()
-            X_vect = scaler.fit_transform(X_vect)
+            self.X_vect = scaler.fit_transform(self.X_vect)
 
-        return X_vect, y
-
+        return self.X_vect, self.y
 
     def split_data(self, X_vect, y):
 
@@ -83,7 +157,7 @@ class GrantTagger():
         random_index = list(range(len(y)))
         seed(self.split_seed)
         shuffle(random_index)
-        if self.vectorizer_type == 'bert':
+        if self.vectorizer_type == "bert":
             X_vect = [X_vect[i] for i in random_index]
         else:
             X_vect = X_vect[random_index]
@@ -91,84 +165,222 @@ class GrantTagger():
 
         relevant_sample_index = [ind for ind, x in enumerate(y) if x != 0]
         irrelevant_sample_index = [ind for ind, x in enumerate(y) if x == 0]
-        sample_size = int(round(len(relevant_sample_index) * self.relevant_sample_ratio))
+        sample_size = int(
+            round(len(relevant_sample_index) * self.relevant_sample_ratio)
+        )
         if sample_size < len(irrelevant_sample_index):
             # Take sample_size equally spaced irrelevant points
-            idx = np.round(np.linspace(0, len(irrelevant_sample_index) - 1, sample_size)).astype(int)
-            sample_index = relevant_sample_index + [irrelevant_sample_index[i] for i in idx]
+            idx = np.round(
+                np.linspace(0, len(irrelevant_sample_index) - 1, sample_size)
+            ).astype(int)
+            sample_index = relevant_sample_index + [
+                irrelevant_sample_index[i] for i in idx
+            ]
             # Make sure they are in order otherwise it'll be all 1111s and then 0000s
             sample_index.sort()
             y = [y[i] for i in sample_index]
-            if self.vectorizer_type == 'bert':
+            if self.vectorizer_type == "bert":
                 X_vect = [X_vect[i] for i in sample_index]
             else:
                 X_vect = X_vect[sample_index]
 
         # Randomly shuffled at the beginning so turn this off
         X_train, X_test, y_train, y_test = train_test_split(
-            X_vect,
-            y,
-            test_size=self.test_size,
-            shuffle=False
-            )
+            X_vect, y, test_size=self.test_size, shuffle=False
+        )
 
         return X_train, X_test, y_train, y_test
 
     def fit(self, X, y):
-        if self.classifier_type == 'naive_bayes':
+        if self.classifier_type == "naive_bayes":
             model = MultinomialNB()
-        elif self.classifier_type == 'SVM':
+        elif self.classifier_type == "SVM":
             model = SVC()
-        elif self.classifier_type == 'log_reg':
+        elif self.classifier_type == "log_reg":
             model = LogisticRegression(max_iter=1000)
         else:
-            print('Model type not recognised')
+            print("Model type not recognised")
         self.model = model.fit(X, y)
 
     def predict(self, X):
         return self.model.predict(X)
 
-    def evaluate(self, X, y, print_results=False, average='binary'):
+    def predict_proba(self, X):
+        return self.model.predict_proba(X)
+
+    def evaluate(self, X, y, extra_scores=False, average="binary"):
 
         y_predict = self.model.predict(X)
 
         scores = {
-            'accuracy': accuracy_score(y, y_predict),
-            'f1': f1_score(y, y_predict, average=average),
-            'precision_score': precision_score(y, y_predict, zero_division=0, average=average),
-            'recall_score': recall_score(y, y_predict, zero_division=0, average=average)}
+            "size": len(y),
+            "accuracy": accuracy_score(y, y_predict),
+            "f1": f1_score(y, y_predict, average=average),
+            "precision_score": precision_score(
+                y, y_predict, zero_division=0, average=average
+            ),
+            "recall_score": recall_score(
+                y, y_predict, zero_division=0, average=average
+            ),
+        }
 
-        if print_results:
-            print(scores)
-            print(classification_report(y, y_predict))
-            print(pretty_confusion_matrix(y, y_predict))
+        if extra_scores:
+            scores["Classification report"] = classification_report(y, y_predict)
+            scores["Confusion matrix"] = pretty_confusion_matrix(y, y_predict)
 
-        return scores, classification_report(y, y_predict), pretty_confusion_matrix(y, y_predict)
+        return scores
+
+    def train_test_info(self):
+        """
+        Output a dict of information about the trained model's use of the data
+        and the predictions and probabilities given, e.g
+        {
+            '123456/X/13/A': {
+                'Truth': 1,
+                'Prediction': 1,
+                'Prediction probability': 0.7,
+                'Test/train': 'Test'
+            }
+        }
+        """
+
+        y_predict = self.model.predict(self.X_vect)
+        y_predict_proba = self.model.predict_proba(self.X_vect)
+        # The probability of the predicted binary value
+        y_predict_proba = np.max(y_predict_proba, axis=1)
+
+        X_train_ids, X_test_ids, _, _ = self.split_data(np.array(self.X_ids), self.y)
+
+        training_info = {}
+        for grant_id, actual, pred, pred_prob in zip(
+            self.X_ids, self.y, y_predict, y_predict_proba
+        ):
+            if grant_id in X_train_ids:
+                split_type = "Train"
+            elif grant_id in X_test_ids:
+                split_type = "Test"
+            else:
+                split_type = "Not used"
+            training_info[grant_id] = {
+                "Truth": int(actual),
+                "Prediction": int(pred),
+                "Prediction probability": pred_prob,
+                "Test/train": split_type,
+            }
+
+        return training_info
 
     def save_model(self, output_path, evaluation_results=None):
         if not os.path.exists(output_path):
             os.makedirs(output_path)
 
-        with open(os.path.join(output_path, 'model.pickle'), 'wb') as f:
+        with open(os.path.join(output_path, "model.pickle"), "wb") as f:
             pickle.dump(self.model, f)
-        with open(os.path.join(output_path, 'vectorizer.pickle'), 'wb') as f:
+        with open(os.path.join(output_path, "vectorizer.pickle"), "wb") as f:
             pickle.dump(self.vectorizer, f)
 
         if evaluation_results:
-            evaluation_results['Vectorizer type'] = self.vectorizer_type
-            evaluation_results['Classifier type'] = self.classifier_type
-            with open(os.path.join(output_path, 'training_information.txt'), 'w') as f:
+            evaluation_results["Vectorizer type"] = self.vectorizer_type
+            evaluation_results["Classifier type"] = self.classifier_type
+            evaluation_results["Split seed"] = self.split_seed
+            with open(os.path.join(output_path, "evaluation_results.txt"), "w") as f:
                 for key, value in evaluation_results.items():
-                    f.write('\n' + key + ': ' + str(value))
+                    f.write("\n" + key + ": " + str(value))
 
     def load_model(self, output_path):
-        with open(os.path.join(output_path, 'model.pickle'), 'rb') as f:
+        with open(os.path.join(output_path, "model.pickle"), "rb") as f:
             self.model = pickle.load(f)
-        with open(os.path.join(output_path, 'vectorizer.pickle'), 'rb') as f:
+        with open(os.path.join(output_path, "vectorizer.pickle"), "rb") as f:
             self.vectorizer = pickle.load(f)
 
 
-if __name__ == '__main__':
+def load_training_data(config, prediction_cols, train_data_id):
+
+    training_data = pd.read_csv(config["data"]["training_data_file"])
+
+    if "grants_text_data_file" in config["data"]:
+        # Merge training data with another dataset containing the
+        # text columns for predicting on
+        grants_data = pd.read_csv(config["data"]["grants_text_data_file"])
+        right_id = config["data"]["grants_text_data_file_id"]
+        training_data = pd.merge(
+            training_data,
+            grants_data.drop_duplicates(subset="Internal ID")[
+                prediction_cols + [right_id]
+            ],
+            how="left",
+            left_on=train_data_id,
+            right_on=right_id,
+        )
+
+    return training_data
+
+
+def train_several_models(config):
+
+    # Load data and parameters
+    vectorizer_types = ast.literal_eval(config["models"]["vectorizer_types"])
+    classifier_types = ast.literal_eval(config["models"]["classifier_types"])
+
+    relevant_sample_ratio = config.getfloat("params", "relevant_sample_ratio")
+    test_size = config.getfloat("params", "test_size")
+    split_seed = config["params"].getint("split_seed")
+
+    prediction_cols = ast.literal_eval(config["data"]["prediction_cols"])
+    label_name = config["data"]["label_name"]
+    train_data_id = config["data"]["training_data_file_id"]
+    training_data = load_training_data(config, prediction_cols, train_data_id)
+
+    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
+
+    # Train and save several models
+    all_training_info = {}
+    for vectorizer_type in vectorizer_types:
+        for classifier_type in classifier_types:
+            print(f"Training for {vectorizer_type} + {classifier_type} ...")
+
+            if not split_seed:
+                split_seed = np.random.randint(100)  # Pick randomly if not given
+            grant_tagger = GrantTagger(
+                test_size=test_size,
+                relevant_sample_ratio=relevant_sample_ratio,
+                split_seed=split_seed,
+                vectorizer_type=vectorizer_type,
+                classifier_type=classifier_type,
+                prediction_cols=prediction_cols,
+                label_name=label_name,
+            )
+            X_vect, y = grant_tagger.transform(training_data, train_data_id)
+
+            X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+
+            grant_tagger.fit(X_train, y_train)
+
+            grant_info = grant_tagger.train_test_info()
+
+            train_scores = grant_tagger.evaluate(X_train, y_train, extra_scores=True)
+            test_scores = grant_tagger.evaluate(X_test, y_test, extra_scores=True)
+
+            evaluation_results = {
+                "Train model config": args.config_path,
+                "Train scores": train_scores,
+                "Test scores": test_scores,
+            }
+
+            outout_name = "_".join([vectorizer_type, classifier_type, config_version])
+            grant_tagger.save_model(
+                os.path.join("models", config_version, outout_name),
+                evaluation_results=evaluation_results,
+            )
+            all_training_info[outout_name] = grant_info
+
+    with open(
+        os.path.join("models", config_version, "training_information.json"), "w"
+    ) as f:
+        f.write(json.dumps(all_training_info))
+
+
+if __name__ == "__main__":
 
     parser = ArgumentParser()
 
@@ -183,95 +395,4 @@ if __name__ == '__main__':
     config = configparser.ConfigParser()
     config.read(args.config_path)
 
-    # datestamp = datetime.now().date().strftime('%y%m%d')
-
-    vectorizer_types = ast.literal_eval(config["models"]["vectorizer_types"])
-    classifier_types = ast.literal_eval(config["models"]["classifier_types"])
-
-    relevant_sample_ratio = config.getfloat("params", "relevant_sample_ratio")
-    test_size = config.getfloat("params", "test_size")
-    split_seed = config.getint("params", "split_seed")
-
-    prediction_cols = ast.literal_eval(config["data"]["prediction_cols"])
-    label_name = config["data"]["label_name"]
-    train_data_id = config["data"]["training_data_file_id"]
-
-    training_data = pd.read_csv(config["data"]["training_data_file"])
-
-    if "grants_text_data_file" in config["data"]:
-        # Merge training data with another dataset containing the
-        # text columns for predicting on
-        grants_data = pd.read_csv(config["data"]["grants_text_data_file"])
-        right_id = config["data"]["grants_text_data_file_id"]
-        training_data = pd.merge(
-            training_data,
-            grants_data.drop_duplicates(subset='Internal ID')[prediction_cols+[right_id]],
-            how='left',
-            left_on=train_data_id,
-            right_on=right_id)
-
-    # Output the data to a dated folder using the config version date
-    # but convert this from 2020.08.07 -> 200807
-    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
-
-    #!!!!!! DELETE!!!!!
-    vectorizer_types = ['count', 'tfidf']
-    classifier_types = ['naive_bayes', 'log_reg']
-    #!!!!!! !!!!!
-    
-    for vectorizer_type in vectorizer_types:
-        for classifier_type in classifier_types:
-            print(f"Training for {vectorizer_type} + {classifier_type} ...")
-
-            grant_tagger = GrantTagger(
-                test_size=test_size,
-                relevant_sample_ratio=relevant_sample_ratio,
-                split_seed=split_seed,
-                vectorizer_type=vectorizer_type,
-                classifier_type=classifier_type,
-                prediction_cols=prediction_cols,
-                label_name=label_name
-            )
-            X_vect, y = grant_tagger.transform(training_data)
-
-            X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
-
-            grant_tagger.fit(X_train, y_train)
-
-            train_scores, _, _ = grant_tagger.evaluate(X_train, y_train)
-            test_scores, test_class_rep, test_conf_mat = grant_tagger.evaluate(X_test, y_test)
-            evaluation_results = {
-                'Train model config': args.config_path,
-                'Train scores': train_scores,
-                'Test scores': test_scores,
-                'Train size': len(y_train),
-                'Test size': len(y_test),
-                'Test classification report': test_class_rep,
-                'Test confusion matrix': test_conf_mat
-                }
-
-            outout_name = '_'.join(
-                [vectorizer_type, classifier_type, config_version]
-                )
-            grant_tagger.save_model(
-                os.path.join('models', config_version, outout_name),
-                evaluation_results=evaluation_results
-                )
-
-    # Output train/test split used for these models
-    # grant code - label - train/test
-    grant_tagger = GrantTagger(
-                test_size=test_size,
-                relevant_sample_ratio=relevant_sample_ratio,
-                split_seed=split_seed
-            )
-
-    X_train, X_test, y_train, y_test = grant_tagger.split_data(
-        training_data[train_data_id],
-        training_data[label_name].astype(int)
-        )
-    train_split = pd.concat([
-        pd.DataFrame({train_data_id: X_train, label_name: y_train, 'Train/test': ['Train']*len(y_train)}),
-        pd.DataFrame({train_data_id: X_test, label_name: y_test, 'Train/test': ['Test']*len(y_test)})
-        ])
-    train_split.to_csv(os.path.join('models', config_version, 'test_train_split.csv'), index=False)
+    train_several_models(config)

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -138,7 +138,7 @@ class GrantTagger:
                 token_pattern=r"(?u)\b\w+\b",
                 ngram_range=(1, 2),
             )
-        elif self.vectorizer_type == "bert":
+        elif "bert" in self.vectorizer_type:
             self.vectorizer = BertVectorizer(pretrained=self.vectorizer_type)
         else:
             print("Vectorizer type not recognised")
@@ -333,7 +333,6 @@ def train_several_models(config):
     config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
 
     # Train and save several models
-    all_training_info = {}
     for vectorizer_type in vectorizer_types:
         for classifier_type in classifier_types:
             print(f"Training for {vectorizer_type} + {classifier_type} ...")
@@ -371,12 +370,12 @@ def train_several_models(config):
                 os.path.join("models", config_version, outout_name),
                 evaluation_results=evaluation_results,
             )
-            all_training_info[outout_name] = grant_info
 
-    with open(
-        os.path.join("models", config_version, "training_information.json"), "w"
-    ) as f:
-        f.write(json.dumps(all_training_info))
+            with open(
+                os.path.join("models", config_version, "training_information.json"), "a"
+            ) as f:
+                f.write(json.dumps({outout_name: grant_info}))
+                f.write('\n')
 
 
 if __name__ == "__main__":

--- a/tests/test_grant_tagger.py
+++ b/tests/test_grant_tagger.py
@@ -1,0 +1,137 @@
+import pytest
+
+import pandas as pd
+
+from nutrition_labels.grant_tagger import GrantTagger
+
+
+training_data = pd.DataFrame(
+    [
+        {
+            'text_field': 'Genetics grant to help medicine.',
+            'text_field_2': 'Genes linked to illnesses.',
+            'Label': 0,
+            'ID': 4
+        },
+        {
+            'text_field': 'The history of medicine.',
+            'text_field_2': 'Books about medicine and genes.',
+            'Label': 0,
+            'ID': 1
+        },
+        {
+            'text_field': 'Creating software tools to further technology.',
+            'text_field_2': 'Coding in Python.',
+            'Label': 1,
+            'ID': 2
+        },
+        {
+            'text_field': 'Technology tools will be created.',
+            'text_field_2': 'Python and other languages.',
+            'Label': 1,
+            'ID': 0
+        },
+        {
+            'text_field': 'In this grant we hope to create new software',
+            'text_field_2': 'Tools will be created.',
+            'Label': 1,
+            'ID': 3
+        },
+        {
+            'text_field': 'Software will be created.',
+            'text_field_2': 'Machine learning tools.',
+            'Label': 1,
+            'ID': 5
+        }
+    ]
+    )
+
+
+prediction_cols = ['text_field', 'text_field_2']
+label_name = 'Label'
+train_data_id = 'ID'
+
+def test_transform():
+
+    grant_tagger = GrantTagger(
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+
+    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+
+    assert X_vect.shape[0] == 6
+    assert grant_tagger.X_ids == [4, 1, 2, 0, 3, 5]
+
+def test_split_data():
+
+    grant_tagger = GrantTagger(
+        test_size=1/3,
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+
+    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+    assert len(y_train) == 4
+    assert len(y_test) == 2
+
+def test_split_relevant_sample_ratio():
+
+    grant_tagger = GrantTagger(
+        relevant_sample_ratio=0.25,
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+
+    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+    all_y = y_train + y_test
+    assert len(all_y) == 5
+    assert len([y for y in all_y if y==0]) == 1
+
+    grant_tagger = GrantTagger(
+        relevant_sample_ratio=0.5,
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+
+    y = [0, 0, 0, 0, 1, 1]
+    
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+    assert len(y_train + y_test) == 3
+
+    grant_tagger = GrantTagger(
+        relevant_sample_ratio=1,
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+    assert len(y_train + y_test) == 4
+
+    grant_tagger = GrantTagger(
+        relevant_sample_ratio=2,
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+    assert len(y_train + y_test) == 6
+
+def test_train_test_info():
+
+    grant_tagger = GrantTagger(
+        relevant_sample_ratio=1,
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+
+    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+    X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
+    grant_tagger.fit(X_train, y_train)
+    grant_info = grant_tagger.train_test_info()
+
+    training_data_truth_dict = dict(zip(training_data.ID, training_data.Label))
+    output_truth_dict = {k:v['Truth'] for k, v in grant_info.items()}
+
+    assert output_truth_dict == training_data_truth_dict


### PR DESCRIPTION
https://trello.com/c/ybAUoW2W/1199-tech-model-refactor-train-multiple-models

Part of https://github.com/wellcometrust/nutrition-labels/issues/62

The main changes are in `grant_tagger.py`.

Previously we ran `grant_tagger.py` with many different arguments to train all the different model vectoriser + classifier combinations. Thus we had to run it 12 times with different arguments.

In this PR:
- `grant_tagger.py` will now train several models with details given in a config file, so only need to run once.
- The GrantTagger class isn't that different - just parameterising certain values, including probabilities in outputs, outputting train/test information (which data points were in test or train and the predictions for each model)
- Tests added for GrantTagger
- Updated README
- Docstrings
- No longer 'bert_type' parameter - just finds this from vectorizer. Before you had to do `vectorizer_type='bert'` and `bert_type='scibert'` to use scibert, but now its just `vectorizer_type='scibert'`.