### PR TITLE
Separate out fit_transform and transform functions in Grant Tagger

### DIFF
--- a/notebooks/Grant tagger experimentation.ipynb
+++ b/notebooks/Grant tagger experimentation.ipynb
@@ -124,7 +124,7 @@
     "                model_type = model_type,\n",
     "                bert_type = bert_type\n",
     "            )\n",
-    "    X_vect,y = grant_tagger.transform(data)\n",
+    "    X_vect,y = grant_tagger.fit_transform(data)\n",
     "    for n in relevant_sample_ratio_range:\n",
     "        average_results_train = None\n",
     "        average_results_test = None\n",
@@ -304,7 +304,7 @@
     "                model_type = model_type,\n",
     "                bert_type = bert_type\n",
     "            )\n",
-    "    X_vect,y = grant_tagger.transform(data)\n",
+    "    X_vect,y = grant_tagger.fit_transform(data)\n",
     "    X_train, X_test, y_train, y_test = grant_tagger.split_data(\n",
     "                X_vect,\n",
     "                y,\n",
@@ -1627,7 +1627,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.7"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -376,7 +376,7 @@ def train_several_models(config):
                 prediction_cols=prediction_cols,
                 label_name=label_name,
             )
-            X_vect, y = grant_tagger.transform(training_data, train_data_id)
+            X_vect, y = grant_tagger.fit_transform(training_data, train_data_id)
 
             X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
 

--- a/nutrition_labels/grant_tagger_evaluation.py
+++ b/nutrition_labels/grant_tagger_evaluation.py
@@ -42,11 +42,7 @@ def evaluate_data(evaluation_data, grant_tagger):
     """
     Predict evaluation data using grant_tagger and return the accuracy score.
     """
-
-    X_eval = evaluation_data[
-        list(grant_tagger.prediction_cols)
-        ].agg(". ".join, axis=1).apply(clean_string).tolist()
-    X_vect_eval = grant_tagger.vectorizer.transform(X_eval) 
+    X_vect_eval = grant_tagger.transform(evaluation_data)
     y_eval = evaluation_data["Relevance code"].tolist()
     eval_scores = grant_tagger.evaluate(X_vect_eval, y_eval)
 

--- a/nutrition_labels/grant_tagger_seed_experiments.py
+++ b/nutrition_labels/grant_tagger_seed_experiments.py
@@ -39,7 +39,7 @@ if __name__ == '__main__':
                     relevant_sample_ratio=relevant_sample_ratio
                     )
 
-            X_vect, y = grant_tagger.transform(data)
+            X_vect, y = grant_tagger.fit_transform(data)
 
             evaluation_results_runs = []
             for split_seed in range(num_rand_seeds):

--- a/tests/test_grant_tagger.py
+++ b/tests/test_grant_tagger.py
@@ -51,6 +51,18 @@ prediction_cols = ['text_field', 'text_field_2']
 label_name = 'Label'
 train_data_id = 'ID'
 
+def test_fit_transform():
+
+    grant_tagger = GrantTagger(
+        prediction_cols=prediction_cols,
+        label_name=label_name,
+        )
+
+    X_vect, y = grant_tagger.fit_transform(training_data, train_data_id)
+
+    assert X_vect.shape[0] == 6
+    assert grant_tagger.X_ids == [4, 1, 2, 0, 3, 5]
+
 def test_transform():
 
     grant_tagger = GrantTagger(
@@ -58,10 +70,10 @@ def test_transform():
         label_name=label_name,
         )
 
-    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+    X_vect_fit_transform, _ = grant_tagger.fit_transform(training_data, train_data_id)
+    X_vect_transform = grant_tagger.transform(training_data)
 
-    assert X_vect.shape[0] == 6
-    assert grant_tagger.X_ids == [4, 1, 2, 0, 3, 5]
+    assert X_vect_fit_transform.shape == X_vect_transform.shape
 
 def test_split_data():
 
@@ -71,7 +83,7 @@ def test_split_data():
         label_name=label_name,
         )
 
-    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+    X_vect, y = grant_tagger.fit_transform(training_data, train_data_id)
     X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
     assert len(y_train) == 4
     assert len(y_test) == 2
@@ -84,7 +96,7 @@ def test_split_relevant_sample_ratio():
         label_name=label_name,
         )
 
-    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+    X_vect, y = grant_tagger.fit_transform(training_data, train_data_id)
 
     X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
     all_y = y_train + y_test
@@ -126,7 +138,7 @@ def test_train_test_info():
         label_name=label_name,
         )
 
-    X_vect, y = grant_tagger.transform(training_data, train_data_id)
+    X_vect, y = grant_tagger.fit_transform(training_data, train_data_id)
     X_train, X_test, y_train, y_test = grant_tagger.split_data(X_vect, y)
     grant_tagger.fit(X_train, y_train)
     grant_info = grant_tagger.train_test_info()


### PR DESCRIPTION
I realised there is no separate function to transform new texts when the vectorizer is already fitted.

- rename grant tagger `transform` to `fit_transform`
- create separate `transform` function to transform new texts using a fitted vectorizer. 
- Update old use of `transform` accordingly. 
- Add test for this.