### PR TITLE
Modifications to the ensemble pipeline

### DIFF
--- a/configs/ensemble/2021.01.29.ini
+++ b/configs/ensemble/2021.01.29.ini
@@ -9,4 +9,4 @@ grant_id_col = Reference
 
 [ensemble_model]
 num_agree = 3
-model_dirs = models/bert_naive_bayes_scibert_210128,models/bert_SVM_scibert_210128,models/tfidf_log_reg_210128,models/tfidf_SVM_210128
+model_dirs = models/210128/bert_naive_bayes_scibert_210128,models/210128/bert_SVM_scibert_210128,models/210128/tfidf_log_reg_210128,models/210128/tfidf_SVM_210128

--- a/configs/ensemble/2021.02.20.ini
+++ b/configs/ensemble/2021.02.20.ini
@@ -9,4 +9,4 @@ grant_id_col = Internal ID
 
 [ensemble_model]
 num_agree = 2
-model_dirs = models/bert_log_reg_bert_210221,models/bert_SVM_bert_210221,models/count_naive_bayes_210221
+model_dirs = models/210221/bert_log_reg_bert_210221,models/210221/bert_SVM_bert_210221,models/210221/count_naive_bayes_210221

--- a/configs/ensemble/2021.04.01.ini
+++ b/configs/ensemble/2021.04.01.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.01
+description = Ensemble model parameters based of best overall results from 210401 models
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+
+[ensemble_model]
+num_agree = 2
+pred_prob_thresh = 0.55
+model_dirs = models/210401/tfidf_SVM_210401,models/210401/bert_naive_bayes_210401,models/210401/bert_log_reg_210401

--- a/nutrition_labels/ensemble_grant_tagger.py
+++ b/nutrition_labels/ensemble_grant_tagger.py
@@ -14,12 +14,14 @@ python ensemble_grant_tagger.py --config_path configs/ensemble/2021.02.19.ini
 from argparse import ArgumentParser
 import configparser
 import os
-from datetime import datetime
 
 import pandas as pd
+from sklearn.pipeline import Pipeline
 
 from nutrition_labels.grant_tagger import GrantTagger
 from nutrition_labels.utils import clean_string
+
+from wellcomeml.ml import WellcomeVotingClassifier
 
 class EnsembleGrantTagger():
     def __init__(
@@ -27,35 +29,24 @@ class EnsembleGrantTagger():
         model_dirs,
         num_agree=3,
         grant_text_cols = ['Title', 'Grant Programme:Title', 'Description'],
-        grant_id_col = 'Internal ID'):
+        grant_id_col = 'Internal ID',
+        pred_prob_threshold = None):
         self.model_dirs = model_dirs
         self.num_agree = num_agree
         self.grant_text_cols = grant_text_cols
         self.grant_id_col = grant_id_col
-
-
-    def clean_grants_data(self, previous_grant_data):
-        """
-        Clean grant descriptions of html
-        Merge the grant descriptions columns into one
-        """
-        grant_data = previous_grant_data.copy()
-        grant_data.fillna('', inplace=True)
-        grant_data[self.grant_text_cols] = grant_data[self.grant_text_cols].applymap(
-            clean_string
-            )
-
-        grant_data['Grant texts'] = grant_data[self.grant_text_cols].agg(
-                '. '.join, axis=1
-                ).tolist()
-        return grant_data
+        self.pred_prob_threshold = pred_prob_threshold
 
     def load_grants_text(self, grants_data_path):
         """
-        Field names need an update here!
+        Load and clean grant descriptions for predictions.
+        Do this once here rather that for each model in the ensemble.
         """
         grant_data = pd.read_csv(grants_data_path)
-        grant_data = self.clean_grants_data(grant_data)
+
+        grant_tagger = GrantTagger(prediction_cols=self.grant_text_cols)
+        grant_data = grant_tagger.process_grant_text(grant_data)
+
         grants_text = grant_data['Grant texts'].tolist()
         self.grants_ids = grant_data[self.grant_id_col].tolist()
 
@@ -64,44 +55,34 @@ class EnsembleGrantTagger():
     def load_model(self, model_path):
 
         # Loading a trained model and vectorizer to predict on all the grants data:
-        grant_tagger_loaded = GrantTagger()
+        grant_tagger_loaded = GrantTagger(pred_prob_threshold=self.pred_prob_threshold)
         grant_tagger_loaded.load_model(model_path)
 
         return grant_tagger_loaded
 
-    def predict_tags(self, grant_tagger_loaded, grants_text):
-
-        new_grants_vect = grant_tagger_loaded.vectorizer.transform(grants_text)
-        predictions = grant_tagger_loaded.predict(new_grants_vect)
-
-        # # Do something if grants_text is ' . . ' or 'Not available' or len<threshold?
-        # grant_data = grant_data[grant_data['Description'] != 'Not available']
-        # grant_data.dropna(subset=['Description'], inplace=True)
-
-        return predictions
-
-
     def predict(self, grants_text):
         """
         Predict whether grant texts (list) are tech grants or not 
-        using an agreement of num_agree
-        of the models in model_dirs
+        using an agreement of num_agree of the models in model_dirs
         """
 
-        model_predictions = {}
+        ensemble_pipelines = []
         for model_dir in self.model_dirs:
-            model_name = os.path.basename(model_dir)
-            print(f'Predicting for {model_name}...')
             grant_tagger_loaded = self.load_model(model_dir)
-            model_predictions[f'{model_name} predictions'] = self.predict_tags(
-                grant_tagger_loaded,
-                grants_text
+            ensemble_pipelines.append(
+                Pipeline([('vect', grant_tagger_loaded), ('est', grant_tagger_loaded)])
                 )
 
-        model_predictions_df = pd.DataFrame(model_predictions)
-        prediction_sums = model_predictions_df.sum(axis=1) 
- 
-        self.final_predictions = (prediction_sums >= self.num_agree).astype(int).tolist()
+        voting_classifier = WellcomeVotingClassifier(
+            estimators=ensemble_pipelines,
+            voting="hard",
+            num_agree=self.num_agree
+        )
+
+        self.final_predictions = voting_classifier.predict(
+            pd.DataFrame({"Grant texts": grants_text})
+            )
+
         return self.final_predictions
 
     def output_tagged_grants(self, output_path):
@@ -122,7 +103,7 @@ if __name__ == '__main__':
     parser.add_argument(
         '--config_path',
         help='Path to config file',
-        default='configs/ensemble/2021.02.20.ini'
+        default='configs/ensemble/2021.04.01.ini'
     )
 
     args = parser.parse_args()
@@ -130,17 +111,24 @@ if __name__ == '__main__':
     config = configparser.ConfigParser()
     config.read(args.config_path)
 
-    datestamp = datetime.now().date().strftime('%y%m%d')
+    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
 
     grants_data_path = config["prediction_data"]["grants_data_path"]
     input_file_name = os.path.basename(grants_data_path).split('.')[0]
-    output_path = f'data/processed/ensemble/{datestamp}/{input_file_name}_tagged.csv'
+    output_path = f'data/processed/ensemble/{config_version}/{input_file_name}_tagged.csv'
+
+    try:
+        pred_prob_thresh = config.getfloat("ensemble_model", "pred_prob_thresh")
+    except:
+        pred_prob_thresh = None
 
     tech_grant_model = EnsembleGrantTagger(
-        model_dirs=config["ensemble_model"]["model_dirs"].split(','), # ['models/count_naive_bayes_210218']
+        model_dirs=config["ensemble_model"]["model_dirs"].split(','),
         num_agree=config.getint("ensemble_model", "num_agree"),
         grant_text_cols=config["prediction_data"]["grant_text_cols"].split(','),
-        grant_id_col=config["prediction_data"]["grant_id_col"])
+        grant_id_col=config["prediction_data"]["grant_id_col"],
+        pred_prob_threshold=pred_prob_thresh
+        )
 
     grants_text = tech_grant_model.load_grants_text(grants_data_path)
     final_predictions = tech_grant_model.predict(grants_text)

--- a/nutrition_labels/ensemble_grant_tagger.py
+++ b/nutrition_labels/ensemble_grant_tagger.py
@@ -30,12 +30,12 @@ class EnsembleGrantTagger():
         num_agree=3,
         grant_text_cols = ['Title', 'Grant Programme:Title', 'Description'],
         grant_id_col = 'Internal ID',
-        pred_prob_threshold = None):
+        threshold = None):
         self.model_dirs = model_dirs
         self.num_agree = num_agree
         self.grant_text_cols = grant_text_cols
         self.grant_id_col = grant_id_col
-        self.pred_prob_threshold = pred_prob_threshold
+        self.threshold = threshold
 
     def load_grants_text(self, grants_data_path):
         """
@@ -55,7 +55,7 @@ class EnsembleGrantTagger():
     def load_model(self, model_path):
 
         # Loading a trained model and vectorizer to predict on all the grants data:
-        grant_tagger_loaded = GrantTagger(pred_prob_threshold=self.pred_prob_threshold)
+        grant_tagger_loaded = GrantTagger(threshold=self.threshold)
         grant_tagger_loaded.load_model(model_path)
 
         return grant_tagger_loaded
@@ -127,7 +127,7 @@ if __name__ == '__main__':
         num_agree=config.getint("ensemble_model", "num_agree"),
         grant_text_cols=config["prediction_data"]["grant_text_cols"].split(','),
         grant_id_col=config["prediction_data"]["grant_id_col"],
-        pred_prob_threshold=pred_prob_thresh
+        threshold=pred_prob_thresh
         )
 
     grants_text = tech_grant_model.load_grants_text(grants_data_path)

--- a/nutrition_labels/grant_tagger.py
+++ b/nutrition_labels/grant_tagger.py
@@ -74,7 +74,7 @@ class GrantTagger:
         they will be merged into one. 
     label_name : str (default "Relevance code")
         The column name of the classification truth label.
-    pred_prob_threshold : float (default None)
+    threshold : float (default None)
         A prediction probability threshold that needs to be satisfied for a datapoint
         to be predicted as tech.
 
@@ -111,7 +111,7 @@ class GrantTagger:
         classifier_type="naive_bayes",
         prediction_cols=["Title", "Grant Programme:Title", "Description"],
         label_name="Relevance code",
-        pred_prob_threshold=None,
+        threshold=None,
     ):
         self.test_size = test_size
         self.relevant_sample_ratio = relevant_sample_ratio
@@ -120,7 +120,7 @@ class GrantTagger:
         self.classifier_type = classifier_type
         self.prediction_cols = (*prediction_cols,)
         self.label_name = label_name
-        self.pred_prob_threshold = pred_prob_threshold
+        self.threshold = threshold
 
     def process_grant_text(self, data):
         """
@@ -242,12 +242,12 @@ class GrantTagger:
 
     def predict(self, X):
         y_predict = self.model.predict(X).astype(int)
-        if self.pred_prob_threshold:
+        if self.threshold:
             # If the prediction probability is over a threshold then allow a 1
             # prediction to stay as 1, otherwise switch to 0.
             # A prediction of 0 will stay at 0 regardless of probability.
             pred_probs = self.model.predict_proba(X)
-            y_predict = y_predict*(np.max(pred_probs, axis=1) >= self.pred_prob_threshold)
+            y_predict = y_predict*(np.max(pred_probs, axis=1) >= self.threshold)
 
         return y_predict
 

--- a/tests/test_ensemble_grant_tagger.py
+++ b/tests/test_ensemble_grant_tagger.py
@@ -1,5 +1,4 @@
 import pytest
-import tempfile
 import os
 
 import pandas as pd
@@ -20,66 +19,64 @@ text_data = pd.DataFrame(
             ]
         )
 
-def test_load_grants_text():
+def test_load_grants_text(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        grants_data_path = os.path.join(tmp_dir, 'text_data.csv')
-        text_data.to_csv(grants_data_path)
-        ensemble_gt = EnsembleGrantTagger(
-            model_dirs = [],
-            grant_text_cols = ['text_1', 'text_2'],
-            grant_id_col = 'id',
-            )
-        grants_text = ensemble_gt.load_grants_text(grants_data_path)
+    grants_data_path = os.path.join(tmp_path, 'text_data.csv')
+    text_data.to_csv(grants_data_path)
+    ensemble_gt = EnsembleGrantTagger(
+        model_dirs = [],
+        grant_text_cols = ['text_1', 'text_2'],
+        grant_id_col = 'id',
+        )
+    grants_text = ensemble_gt.load_grants_text(grants_data_path)
 
-        assert len(grants_text) == 7
-        assert all(text is not None for text in grants_text)
+    assert len(grants_text) == 7
+    assert all(text is not None for text in grants_text)
 
-def test_predict():
+def test_predict(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        model_dirs = []
-        individual_pred = []
-        for i, vectorizer in enumerate(["count", "count", "tfidf"]):
-            grant_tagger = GrantTagger(
-                    vectorizer_type=vectorizer,
-                    classifier_type="naive_bayes",
-                    prediction_cols=['text_1', 'text_2'],
-                    label_name="label",
-                    pred_prob_threshold=None,
-                    )
-            X_vect, y = grant_tagger.fit_transform(text_data, "id")
-            grant_tagger.fit(X_vect[0:3], y[0:3]) # This means count and tdidf results are different
-            individual_pred.append(list(grant_tagger.predict(X_vect)))
-            model_dir = os.path.join(tmp_dir, str(i))
-            grant_tagger.save_model(model_dir)
-            model_dirs.append(model_dir)
-        grants_data_path = os.path.join(tmp_dir, 'text_data.csv')
-        text_data.to_csv(grants_data_path)
+    model_dirs = []
+    individual_pred = []
+    for i, vectorizer in enumerate(["count", "count", "tfidf"]):
+        grant_tagger = GrantTagger(
+                vectorizer_type=vectorizer,
+                classifier_type="naive_bayes",
+                prediction_cols=['text_1', 'text_2'],
+                label_name="label",
+                pred_prob_threshold=None,
+                )
+        X_vect, y = grant_tagger.fit_transform(text_data, "id")
+        grant_tagger.fit(X_vect[0:3], y[0:3]) # This means count and tdidf results are different
+        individual_pred.append(list(grant_tagger.predict(X_vect)))
+        model_dir = os.path.join(tmp_path, str(i))
+        grant_tagger.save_model(model_dir)
+        model_dirs.append(model_dir)
+    grants_data_path = os.path.join(tmp_path, 'text_data.csv')
+    text_data.to_csv(grants_data_path)
 
-        # Test that if 2 need to agree then the output will be the same
-        # as one of the count vectorizer individual outputs
-        ensemble_gt = EnsembleGrantTagger(
-            model_dirs = model_dirs,
-            grant_text_cols = ['text_1', 'text_2'],
-            grant_id_col = 'id',
-            num_agree = 2
-            )
-        grants_text = ensemble_gt.load_grants_text(grants_data_path)
-        final_predictions = ensemble_gt.predict(grants_text)
-        assert final_predictions == individual_pred[0]
-        
-        # Test that with impossibly high threshold everything is returned as 0
-        ensemble_gt = EnsembleGrantTagger(
-            model_dirs = model_dirs,
-            grant_text_cols = ['text_1', 'text_2'],
-            grant_id_col = 'id',
-            num_agree = 2,
-            pred_prob_threshold = 1.1
-            )
-        grants_text = ensemble_gt.load_grants_text(grants_data_path)
-        final_predictions = ensemble_gt.predict(grants_text)
-        assert len(final_predictions) == 7
-        assert all(pred==0 for pred in final_predictions)
+    # Test that if 2 need to agree then the output will be the same
+    # as one of the count vectorizer individual outputs
+    ensemble_gt = EnsembleGrantTagger(
+        model_dirs = model_dirs,
+        grant_text_cols = ['text_1', 'text_2'],
+        grant_id_col = 'id',
+        num_agree = 2
+        )
+    grants_text = ensemble_gt.load_grants_text(grants_data_path)
+    final_predictions = ensemble_gt.predict(grants_text)
+    assert final_predictions == individual_pred[0]
+    
+    # Test that with impossibly high threshold everything is returned as 0
+    ensemble_gt = EnsembleGrantTagger(
+        model_dirs = model_dirs,
+        grant_text_cols = ['text_1', 'text_2'],
+        grant_id_col = 'id',
+        num_agree = 2,
+        pred_prob_threshold = 1.1
+        )
+    grants_text = ensemble_gt.load_grants_text(grants_data_path)
+    final_predictions = ensemble_gt.predict(grants_text)
+    assert len(final_predictions) == 7
+    assert all(pred==0 for pred in final_predictions)
 
         

--- a/tests/test_ensemble_grant_tagger.py
+++ b/tests/test_ensemble_grant_tagger.py
@@ -43,7 +43,7 @@ def test_predict(tmp_path):
                 classifier_type="naive_bayes",
                 prediction_cols=['text_1', 'text_2'],
                 label_name="label",
-                pred_prob_threshold=None,
+                threshold=None,
                 )
         X_vect, y = grant_tagger.fit_transform(text_data, "id")
         grant_tagger.fit(X_vect[0:3], y[0:3]) # This means count and tdidf results are different
@@ -72,7 +72,7 @@ def test_predict(tmp_path):
         grant_text_cols = ['text_1', 'text_2'],
         grant_id_col = 'id',
         num_agree = 2,
-        pred_prob_threshold = 1.1
+        threshold = 1.1
         )
     grants_text = ensemble_gt.load_grants_text(grants_data_path)
     final_predictions = ensemble_gt.predict(grants_text)

--- a/tests/test_grant_tagger_evaluation.py
+++ b/tests/test_grant_tagger_evaluation.py
@@ -1,5 +1,4 @@
 import pytest
-import tempfile
 import os
 import json
 
@@ -26,18 +25,17 @@ model_scores = [
     },
     ]
 
-def test_get_model_test_scores():
+def test_get_model_test_scores(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        with open(os.path.join(tmp_dir, "training_information.json"), "a") as f:
-            for line in model_scores:
-                f.write(json.dumps(line))
-                f.write('\n')
-        all_models_info = get_model_test_scores(tmp_dir)
+    with open(os.path.join(tmp_path, "training_information.json"), "a") as f:
+        for line in model_scores:
+            f.write(json.dumps(line))
+            f.write('\n')
+    all_models_info = get_model_test_scores(tmp_path)
 
-        assert len(all_models_info) == 2
-        assert all_models_info['model_1']['f1'] == 0
-        assert all_models_info['model_2']['f1'] == 1
+    assert len(all_models_info) == 2
+    assert all_models_info['model_1']['f1'] == 0
+    assert all_models_info['model_2']['f1'] == 1
 
 
 def test_get_evaluation_data_scores():

--- a/tests/test_tech_grant_tagger.py
+++ b/tests/test_tech_grant_tagger.py
@@ -1,5 +1,4 @@
 import pytest
-import tempfile
 import os
 
 import pandas as pd
@@ -12,34 +11,32 @@ grants_data = pd.DataFrame([
     {'ID': 456, 'Title': 'Research about cancer cells'},
     {'ID': 789, 'Title': 'We will build a python based mathematical model with open source code on github'}])
 
-def test_load_grants_text():
+def test_load_grants_text(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        grants_data_dir = os.path.join(tmp_dir, 'test.csv')
-        grants_data.to_csv(grants_data_dir)
+    grants_data_dir = os.path.join(tmp_path, 'test.csv')
+    grants_data.to_csv(grants_data_dir)
 
-        tech_grant_model = EnsembleGrantTagger(
-            model_dirs=['models/210331/count_naive_bayes_210331'],
-            num_agree=1,
-            grant_text_cols=['Title'],
-            grant_id_col='ID')
+    tech_grant_model = EnsembleGrantTagger(
+        model_dirs=['models/210331/count_naive_bayes_210331'],
+        num_agree=1,
+        grant_text_cols=['Title'],
+        grant_id_col='ID')
 
-        loaded_grants_data = tech_grant_model.load_grants_text(grants_data_dir)
-        assert len(grants_data)==3
+    loaded_grants_data = tech_grant_model.load_grants_text(grants_data_dir)
+    assert len(grants_data)==3
 
-def test_predict():
+def test_predict(tmp_path):
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        grants_data_dir = os.path.join(tmp_dir, 'test.csv')
-        grants_data.to_csv(grants_data_dir)
+    grants_data_dir = os.path.join(tmp_path, 'test.csv')
+    grants_data.to_csv(grants_data_dir)
 
-        tech_grant_model = EnsembleGrantTagger(
-            model_dirs=['models/210331/count_naive_bayes_210331'],
-            num_agree=1,
-            grant_text_cols=['Title'],
-            grant_id_col='ID')
+    tech_grant_model = EnsembleGrantTagger(
+        model_dirs=['models/210331/count_naive_bayes_210331'],
+        num_agree=1,
+        grant_text_cols=['Title'],
+        grant_id_col='ID')
 
-        loaded_grants_data = tech_grant_model.load_grants_text(grants_data_dir)
-        final_predictions = tech_grant_model.predict(loaded_grants_data)
-        assert len(final_predictions)==3
+    loaded_grants_data = tech_grant_model.load_grants_text(grants_data_dir)
+    final_predictions = tech_grant_model.predict(loaded_grants_data)
+    assert len(final_predictions)==3
     

--- a/tests/test_training_data.py
+++ b/tests/test_training_data.py
@@ -144,7 +144,7 @@ def test_deduplicate_similar_grants():
     assert len(grant_data) == 1
 
 
-def test_load_prodigy_tags():
+def test_load_prodigy_tags(tmp_path):
 
     prodigy_data = [
         {
@@ -179,13 +179,12 @@ def test_load_prodigy_tags():
         },
     ]
 
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        prodigy_data_dir = os.path.join(tmp_dir, "prodigy_data.jsonl")
-        with open(prodigy_data_dir, "w") as json_file:
-            for entry in prodigy_data:
-                json.dump(entry, json_file)
-                json_file.write("\n")
-        training_data = load_prodigy_tags(prodigy_data_dir)
+    prodigy_data_dir = os.path.join(tmp_path, "prodigy_data.jsonl")
+    with open(prodigy_data_dir, "w") as json_file:
+        for entry in prodigy_data:
+            json.dump(entry, json_file)
+            json_file.write("\n")
+    training_data = load_prodigy_tags(prodigy_data_dir)
 
     correct_labels = {
         "987654/A/19/Z": 1,


### PR DESCRIPTION
- Add new 21.04.01 ensemble config
- Use wellcomeml votingclassifier in ensemble model
- Allow option for using a prediction probability threshold
- Some fixes to GrantTagger including converting predictions to integers (previously floats)

I noticed a bug in GrantTagger in which we scaled the vectors for the bert/scibert+naive bayes case, but then didn't include this in `transform`. Since the analysis after this uses the results saved during the training, these are still accurate, but when I tried to replicate them I couldn't. Thus `GrantTagger` has been modified to save out the trained scalers for these cases, and use them if loaded.

After this, I replicated the results from the ensemble parameter exploration notebook, namely that the ensemble model with config ` 21.04.01` gives:
```
             precision    recall  f1-score   support

           0       0.89      0.91      0.90        77
           1       0.91      0.89      0.90        80

    accuracy                           0.90       157
   macro avg       0.90      0.90      0.90       157
weighted avg       0.90      0.90      0.90       157

[[70  7]
 [ 9 71]]
 ```
