### PR TITLE
Scripts for evaluation and predicting

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ We perform cluster analysis to look at themes within the tech grants. This analy
 
 ## Using the tech grants tagger
 
-Create a config file with the name of the grants data csv file you want to predict on, the names of the columns of text, and which models to use and how many need to agree (see `configs/ensemble/2020.02.21.ini` for structure). Then input this config as an argument to `ensemble_grant_tagger.py`, for example:
+Create a config file with the name of the grants data csv file you want to predict on, the names of the columns of text, and which model(s) to use (if multiple then you can also define how many models need to agree) (see `configs/predict/2021.04.02.ini` for structure). Then input this config as an argument to `predict.py`, for example:
 
 ```
-python nutrition_labels/ensemble_grant_tagger.py --config_path configs/ensemble/2020.02.21.ini
+python -i nutrition_labels/predict.py --config_path configs/predict/2021.04.02.ini
 ```
 
 This will output a csv file of grant ID - tech or not predictions.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,26 @@
 
 This repo contains the exploratory notebooks, modelling and analysis scripts to find out what tech Wellcome funds, and also the code to create the data representation labels.
 
-## Set-up
+### Contents
+1. [Set-up](#setup)
+2. [Tech Wellcome Funds](#tech)
+  - [Pipeline overview](#pipelineoverview)
+    - [Create the training data](#pipeline1)
+    - [Train models](#pipeline2)
+    - [Predict tech grants using a single or an ensemble of models](#pipeline3)
+    - [(optional) Create evaluation data](#pipeline4)
+    - [(optional) Evaluate the model](#pipeline5)
+  - [Pipeline additional details](#pipelineadditional)
+    - [Creating training data](#trainingdata)
+    - [Model Experiments](#experiments)
+    - [Fairness](#fairness)
+    - [Computational Science tags comparison](#comparison)
+    - [Clustering](#clustering)
+3. [Data Representation Labels](#labels)
+4. [Project structure](#structure)
+
+## Set-up <a name="setup"></a>
+
 ### Set up the virtual environment
 
 Running
@@ -23,6 +42,7 @@ Download the data for this project from
 https://wellcomecloud.sharepoint.com/:f:/r/sites/DataLabs/Machine%20Learning/Nutrition%20Labels/data?csf=1&web=1&e=XHFn6n
 ```
 you will need to have been granted access to access this folder.
+This data contains the file `data/raw/wellcome-grants-awarded-2005-2019.csv` which is the openly available 360Giving grants data of 16,914 grants from 2005 to 2019. This file is the basis of a lot of this project.
 
 Make sure to upload any processed data to this folder too.
 
@@ -33,14 +53,113 @@ To run a notebook run
 jupyter notebook
 ```
 
-## Tech Wellcome Funds
+### Tests
+
+Unit tests can be run by running `make test`. After any changes made to this codebase this command should be ran in order to check nothing has been broken.
+
+To check the pipeline of training models and predicting grants is working can be done with:
+```
+chmod +x tech_grants_pipeline_test.sh
+./tech_grants_pipeline_test.sh
+```
+this should take about 1 min.
+
+## Tech Wellcome Funds <a name="tech"></a>
 
 The code for this project is in the `nutrition_labels` and `notebooks` folder. More information about the experiments and results to this project are given in the documents:
 - [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md)
 - [Tech_grant_model_fairness.md](docs/Tech_grant_model_fairness.md)
 - [Tech_grant_clusters.md](docs/Tech_grant_clusters.md)
+- [Expanding_tech_grants.md](docs/Expanding_tech_grants.md)
+- [Prodigy_training_data.md](docs/Prodigy_training_data.md)
+- [Tech_Grants_2021.md](docs/Tech_Grants_2021.md) - the most current experiment descriptions are all in this document.
 
-### Creating training data
+### Pipeline overview <a name="pipelineoverview"></a>
+
+The pipeline to create training data, train models, and make predictions and evaluate models can be run with the commands:
+```
+chmod +x tech_grants_pipeline.sh
+./tech_grants_pipeline.sh
+```
+be warned that this takes >5 hours since it includes making predictions on data.
+
+An overview of this pipeline and the latest files, as of 21/04/2021 used for each of them is as follows.
+
+##### 1. Create the training data <a name="pipeline1"></a>
+Description: Create training data with expanded tech definition and tagged grants data. ResearchFish and EPMC data are not included in the data.
+
+Input: `configs/training_data/2021.03.08.ini`
+
+Command:
+```
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.ini
+```
+Output: 313 tech grants and 488 not tech grants (Internal ID <-> Relevance code) `data/processed/training_data/210308/training_data.csv`.
+
+##### 2. Train model(s) <a name="pipeline2"></a>
+Description: Train a BERT + logistic regression classifier model.
+
+Input: `configs/train_model/2021.04.03.ini`
+Command:
+```
+python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.03.ini
+```
+Output:
+All outputs stored in `models/210403/`, the pickled trained classifier and vectorizer is stored in the folder `models/210403/bert_log_reg_210403/` along with a `evaluation_results.txt` file with the test/train metrics. Another file is stored in the main directory `models/210403/training_information.json` which contains information of which data points were in the test/train split and what the model predicted.
+
+##### 3. Predict tech grants using a single or an ensemble of models <a name="pipeline3"></a>
+Description: Predict whether grants should be classified as tech grants or not, using the trained `models/210403/bert_log_reg_210403` model with a prediction threshold of 0.55.
+
+Input: Internally we want to predict on fortytwo data, but for external communication we need to use the public 360 giving dataset. So we have different configs to predict on each of these:
+- `configs/predict/2021.04.04.ini` - to predict using the 360 giving grants dataset.
+- `configs/predict/2021.04.05.ini` - to predict using the fortytwo grants data downloaded on 20th April 2021.
+
+Command:
+```
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.04.ini
+```
+```
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.05.ini
+```
+Output:
+- `data/processed/predictions/210404/wellcome-grants-awarded-2005-2019_tagged.csv`
+- `data/processed/predictions/210405/all_grants_fortytwo_info_210420_tagged.csv`
+
+##### 4. (optional) Create evaluation data <a name="pipeline4"></a>
+Description: A sample of ResearchFish (self-reported) and EPMC (publications) outputs data was tagged as containing a tech output. This can be seen as 'hidden' tech - and so the grants description may not have any mention of tech. It is interesting to see how well the model does on predicting these grants, but first this needs to be processed.
+
+Input:
+- `configs/training_data/2021.03.29.epmc.ini`
+- `configs/training_data/2021.03.29.rf.ini`
+
+Command:
+```
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.epmc.ini
+```
+and
+
+```
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.rf.ini
+```
+
+Output:
+- `data/processed/training_data/210329epmc/training_data.csv`
+- `data/processed/training_data/210329rf/training_data.csv`
+
+##### 5. (optional) Evaluate the model <a name="pipeline5"></a>
+Description: The model is evaluated on up to 4 different datasets - the test data, unseen grants data containing only not-tech grants, and the tech outputs from the EPMC and ResearchFish outputs data. The unseen not-tech grants data was the disregarded set of training data to make the test and training datasets have a balanced number of tech and not tech grants. If step 4 wasn't done, this will still work and just output the test and unseen data metrics.
+
+Input: `configs/evaluation/2021.04.03.ini`
+
+Command:
+```
+python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.03.ini
+```
+Output:
+Metrics for all 4 evaluation data sets are outputted in `data/processed/evaluation/210403/evaluation_results.txt`.
+
+### Pipeline additional details <a name="pipelineadditional"></a>
+#### Creating training data <a name="trainingdata"></a>
 
 In [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md) we describe the first stage of tagging data to create the training data - this was last updated on the 7th August 2020. In 2021 we updated the definition of 'tech' as described in [Expanding_tech_grants.md](docs/Expanding_tech_grants.md) - this created a new training data set on 26th January 2021. Then, we decided to use active learning in Prodigy to tag more training data, this process is described in [Prodigy_training_data.md](docs/Prodigy_training_data.md), this resulted in a training data set on the 21st February 2021.
 
@@ -57,53 +176,29 @@ python nutrition_labels/create_training_data.py --config_path configs/training_d
 ```
 with config files from '2020.08.07.ini', '2021.01.26.ini', '2021.02.21.ini' or 2021.03.08.ini'.
 
+#### Model Experiments <a name="experiments"></a>
 
-### Training a tech tagging model
+Several experiments were performed to come up with the best model for this task. The outcomes of these fed into the design of each of the config files in the pipeline. These experiments are discussed in much more detail in the "Experiments" and "Ensemble model/Parameter experiments" sections of [Tech_Grants_2021.md](docs/Tech_Grants_2021.md).
 
-You can train and save a model, or several models, to classify grants as being to do with tech or not (see definitions for this in [Finding_Tech_Grants.md](docs/Finding_Tech_Grants.md)) by creating a config file which contains various training arguments for the experiments. The main arguments in this config file are:
-
-- `training_data_file`, e.g. `data/processed/training_data/210308/training_data.csv`, the training data file.
-- `vectorizer_types`, e.g. `['count', 'tfidf', 'bert', 'scibert']`, the vectorizers you want to use.
-- `classifier_types`, e.g. `['naive_bayes', 'SVM', 'log_reg']`, the classifier types you want to use.
-
-Then by running 
-```
-python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.03.31.ini
-```
-every combination from `vectorizer_types` and `classifier_types` will be run.
-
-This will create a folder in `models/` named after the config version, and each trained model will be stored in their own subfolders. A summary json file with the model predictions will be stored in e.g. `models/210331/training_information.json`, this will be important in evaluating the ensemble model.
-
-### Fairness
+#### Fairness <a name="fairness"></a>
 
 In the notebook [Fairness.ipynb](notebooks/Fairness.ipynb) we perform group fairness checks for the models. The results of these are written up in [Tech_grant_model_fairness.md](docs/Tech_grant_model_fairness.md).
 
-### Computational Science tags comparison
+#### Computational Science tags comparison <a name="comparison"></a>
 
 We compare the tech grants with another set of grants tagged by a different model in the notebook [Science tags - Tech grant comparison.ipynb](notebooks/Science%20tags%20-%20Tech%20grant%20comparison.ipynb").
 
-### Clustering
+#### Clustering <a name="clustering"></a>
 
 We perform cluster analysis to look at themes within the tech grants. This analysis is written up in [Tech_grant_clusters.md](docs/Tech_grant_clusters.md).
 
-## Using the tech grants tagger
-
-Create a config file with the name of the grants data csv file you want to predict on, the names of the columns of text, and which model(s) to use (if multiple then you can also define how many models need to agree) (see `configs/predict/2021.04.02.ini` for structure). Then input this config as an argument to `predict.py`, for example:
-
-```
-python -i nutrition_labels/predict.py --config_path configs/predict/2021.04.02.ini
-```
-
-This will output a csv file of grant ID - tech or not predictions.
-
-
-## Data Representation Labels
+# Data Representation Labels <a name="labels"></a>
 
 In the [Top_Datasets.md](docs/Top_Datasets.md) document you can find how we identified some of the datasets to include in the data representation labels.
 
 The folder `representation_labels/` contains the code needed to produce the data representation labels html.
 
-## Project structure
+# Project structure <a name="structure"></a>
 
 ```
 ├── configs            

--- a/configs/evaluation/2021.04.02.ini
+++ b/configs/evaluation/2021.04.02.ini
@@ -1,0 +1,20 @@
+[DEFAULT]
+version = 2021.04.02
+description = Evaluation datasets for model parameters based of best overall results from 210402 models.
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+epmc_file_dir = data/processed/training_data/210329epmc/training_data.csv
+rf_file_dir = data/processed/training_data/210329rf/training_data.csv
+eval_id_col = Internal ID
+eval_label_name = Relevance code
+
+[ensemble_model]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210402/bert_log_reg_210402
+
+
+    

--- a/configs/evaluation/2021.04.02.ini
+++ b/configs/evaluation/2021.04.02.ini
@@ -15,6 +15,3 @@ eval_label_name = Relevance code
 num_agree = 1
 pred_prob_thresh = 0.55
 model_dirs = models/210402/bert_log_reg_210402
-
-
-    

--- a/configs/evaluation/2021.04.02.test.ini
+++ b/configs/evaluation/2021.04.02.test.ini
@@ -1,0 +1,19 @@
+[DEFAULT]
+version = 2021.04.02.test
+description = Evaluation datasets for model parameters based of best overall results from 210402 models.
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+epmc_file_dir = data/processed/training_data/210329epmc/training_data.csv
+rf_file_dir = data/processed/training_data/210329rf/training_data.csv
+eval_id_col = Internal ID
+eval_label_name = Relevance code
+
+[ensemble_model]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210402test/count_naive_bayes_210402test
+
+    

--- a/configs/evaluation/2021.04.02.test.ini
+++ b/configs/evaluation/2021.04.02.test.ini
@@ -15,5 +15,3 @@ eval_label_name = Relevance code
 num_agree = 1
 pred_prob_thresh = 0.55
 model_dirs = models/210402test/count_naive_bayes_210402test
-
-    

--- a/configs/evaluation/2021.04.03.ini
+++ b/configs/evaluation/2021.04.03.ini
@@ -15,6 +15,3 @@ eval_label_name = Relevance code
 num_agree = 1
 pred_prob_thresh = 0.55
 model_dirs = models/210403/bert_log_reg_210403
-
-
-    

--- a/configs/evaluation/2021.04.03.ini
+++ b/configs/evaluation/2021.04.03.ini
@@ -1,0 +1,20 @@
+[DEFAULT]
+version = 2021.04.03
+description = Evaluation datasets for model parameters based of best overall results from 210402 models.
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+epmc_file_dir = data/processed/training_data/210329epmc/training_data.csv
+rf_file_dir = data/processed/training_data/210329rf/training_data.csv
+eval_id_col = Internal ID
+eval_label_name = Relevance code
+
+[ensemble_model]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210403/bert_log_reg_210403
+
+
+    

--- a/configs/predict/2021.04.01.ini
+++ b/configs/predict/2021.04.01.ini
@@ -1,6 +1,6 @@
 [DEFAULT]
 version = 2021.04.01
-description = Ensemble model parameters based of best overall results from 210401 models
+description = Predict the training data using the ensemble model parameters based of best overall results from 210401 models
 
 [prediction_data]
 grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv

--- a/configs/predict/2021.04.01.ini
+++ b/configs/predict/2021.04.01.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.01
+description = Ensemble model parameters based of best overall results from 210401 models
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+
+[model_parameters]
+num_agree = 2
+pred_prob_thresh = 0.55
+model_dirs = models/210401/tfidf_SVM_210401,models/210401/bert_naive_bayes_210401,models/210401/bert_log_reg_210401

--- a/configs/predict/2021.04.02.ini
+++ b/configs/predict/2021.04.02.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.02
+description = Predict tech grants from grants data in grants_data_path using the model parameters best for the 2021.04.02 ensemble experiments.
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+
+[model_parameters]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210402/bert_log_reg_210402

--- a/configs/predict/2021.04.02.ini
+++ b/configs/predict/2021.04.02.ini
@@ -1,11 +1,11 @@
 [DEFAULT]
 version = 2021.04.02
-description = Predict tech grants from grants data in grants_data_path using the model parameters best for the 2021.04.02 ensemble experiments.
+description = Predict tech grants in all the 360 giving data using the model parameters best for the 2021.04.02 ensemble experiments.
 
 [prediction_data]
-grants_data_path = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
-grant_text_cols = Title,Synopsis
-grant_id_col = Reference
+grants_data_path = data/raw/wellcome-grants-awarded-2005-2019.csv
+grant_text_cols = Title,Description
+grant_id_col = Internal ID
 
 [model_parameters]
 num_agree = 1

--- a/configs/predict/2021.04.02.test.ini
+++ b/configs/predict/2021.04.02.test.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.02.test
+description = Predict tech grants in all the 360 giving data using the model parameters best for the 2021.04.02 ensemble experiments.
+
+[prediction_data]
+grants_data_path = data/raw/wellcome-grants-awarded-2005-2019_test_sample.csv
+grant_text_cols = Title,Description
+grant_id_col = Internal ID
+
+[model_parameters]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210402test/count_naive_bayes_210402test

--- a/configs/predict/2021.04.03.ini
+++ b/configs/predict/2021.04.03.ini
@@ -3,7 +3,7 @@ version = 2021.04.03
 description = Predict tech grants in all the fortytwo grants data as of 20th April 2021 (query: SELECT Reference, Title, Synopsis FROM FortyTwo_Denormalised.[WTGT].[ApplicationsAndGrantDetails]) using the model parameters best for the 2021.04.02 ensemble experiments.
 
 [prediction_data]
-grants_data_path = data/processed/fortytwo/all_grants_fortytwo_info_210420.csv
+grants_data_path = data/raw/fortytwo/all_grants_fortytwo_info_210420.csv
 grant_text_cols = Title,Synopsis
 grant_id_col = Reference
 

--- a/configs/predict/2021.04.03.ini
+++ b/configs/predict/2021.04.03.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.03
+description = Predict tech grants in all the fortytwo grants data as of 20th April 2021 (query: SELECT Reference, Title, Synopsis FROM FortyTwo_Denormalised.[WTGT].[ApplicationsAndGrantDetails]) using the model parameters best for the 2021.04.02 ensemble experiments.
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/all_grants_fortytwo_info_210420.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+
+[model_parameters]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210402/bert_log_reg_210402

--- a/configs/predict/2021.04.04.ini
+++ b/configs/predict/2021.04.04.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.04
+description = Predict tech grants in all the 360 giving data using the model parameters best for the 2021.04.02 ensemble experiments.
+
+[prediction_data]
+grants_data_path = data/raw/wellcome-grants-awarded-2005-2019.csv
+grant_text_cols = Title,Description
+grant_id_col = Internal ID
+
+[model_parameters]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210403/bert_log_reg_210403

--- a/configs/predict/2021.04.05.ini
+++ b/configs/predict/2021.04.05.ini
@@ -1,0 +1,13 @@
+[DEFAULT]
+version = 2021.04.05
+description = Predict tech grants in all the fortytwo grants data as of 20th April 2021 (query: SELECT Reference, Title, Synopsis FROM FortyTwo_Denormalised.[WTGT].[ApplicationsAndGrantDetails]) using the model parameters best for the 2021.04.03 ensemble experiments.
+
+[prediction_data]
+grants_data_path = data/processed/fortytwo/all_grants_fortytwo_info_210420.csv
+grant_text_cols = Title,Synopsis
+grant_id_col = Reference
+
+[model_parameters]
+num_agree = 1
+pred_prob_thresh = 0.55
+model_dirs = models/210403/bert_log_reg_210403

--- a/configs/predict/2021.04.05.ini
+++ b/configs/predict/2021.04.05.ini
@@ -3,7 +3,7 @@ version = 2021.04.05
 description = Predict tech grants in all the fortytwo grants data as of 20th April 2021 (query: SELECT Reference, Title, Synopsis FROM FortyTwo_Denormalised.[WTGT].[ApplicationsAndGrantDetails]) using the model parameters best for the 2021.04.03 ensemble experiments.
 
 [prediction_data]
-grants_data_path = data/processed/fortytwo/all_grants_fortytwo_info_210420.csv
+grants_data_path = data/raw/fortytwo/all_grants_fortytwo_info_210420.csv
 grant_text_cols = Title,Synopsis
 grant_id_col = Reference
 

--- a/configs/train_model/2021.04.02.test.ini
+++ b/configs/train_model/2021.04.02.test.ini
@@ -1,0 +1,20 @@
+[DEFAULT]
+version = 2021.04.02.test
+description = Train all models with 210308 training data, and use the grant text data from 42, don't include grant type. When vectorizer isn't trained on all data.
+
+[data]
+training_data_file = data/processed/training_data/210308/training_data.csv
+label_name = Relevance code
+training_data_file_id = Internal ID
+prediction_cols = ['Title', 'Synopsis']
+grants_text_data_file = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grants_text_data_file_id = Reference
+
+[models]
+vectorizer_types = ['count', 'tfidf']
+classifier_types = ['naive_bayes', 'SVM']
+
+[params]
+relevant_sample_ratio = 1
+test_size = 0.25
+split_seed = 1

--- a/configs/train_model/2021.04.03.ini
+++ b/configs/train_model/2021.04.03.ini
@@ -1,0 +1,20 @@
+[DEFAULT]
+version = 2021.04.03
+description = Just train a bert + log reg model since after experimentation this was better than any other, or ensemble of other, models. Train using the 210308 training data, and use the grant text data from 42, don't include grant type. When vectorizer isn't trained on all data.
+
+[data]
+training_data_file = data/processed/training_data/210308/training_data.csv
+label_name = Relevance code
+training_data_file_id = Internal ID
+prediction_cols = ['Title', 'Synopsis']
+grants_text_data_file = data/processed/fortytwo/tech_210308_training_data_fortytwo_info.csv
+grants_text_data_file_id = Reference
+
+[models]
+vectorizer_types = ['bert']
+classifier_types = ['log_reg']
+
+[params]
+relevant_sample_ratio = 1
+test_size = 0.25
+split_seed = 1

--- a/configs/training_data/2021.03.08.test.ini
+++ b/configs/training_data/2021.03.08.test.ini
@@ -1,0 +1,18 @@
+[DEFAULT]
+version = 2021.03.08.test
+description = Creating the training data with tech definition being world-wide and not just in the health domain. Prodigy tags included, but don't include research fish or EPMC data points. This config file is for create_training_data.py.
+
+[data]
+epmc_tags_query_one_filedir = data/raw/expanded_tags/EPMC_relevant_tool_pubs_3082020.csv
+epmc_tags_query_two_filedir = data/raw/expanded_tags/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
+rf_tags_filedir = data/raw/expanded_tags/research_fish_manual_edit.csv
+grant_tags_filedir = data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
+prodigy_filedir = data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
+grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv
+sources_include = ['Prodigy grants', 'Grants']
+
+[data_col_ranking]
+epmc_col_ranking = ['Revised code']
+grants_col_ranking = ['Revised code']
+

--- a/configs/training_data/2021.03.29.test.epmc.ini
+++ b/configs/training_data/2021.03.29.test.epmc.ini
@@ -1,0 +1,18 @@
+[DEFAULT]
+version = 2021.03.29.epmctest
+description = Only EPMC data, for use in testing how well the model performs on this out-of-domain data.
+
+[data]
+epmc_tags_query_one_filedir = data/raw/expanded_tags/EPMC_relevant_tool_pubs_3082020.csv
+epmc_tags_query_two_filedir = data/raw/expanded_tags/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
+rf_tags_filedir = data/raw/expanded_tags/research_fish_manual_edit.csv
+grant_tags_filedir = data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
+prodigy_filedir = data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
+grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv
+sources_include = ['EPMC']
+
+[data_col_ranking]
+epmc_col_ranking = ['Revised code']
+grants_col_ranking = ['Revised code']
+

--- a/configs/training_data/2021.03.29.test.rf.ini
+++ b/configs/training_data/2021.03.29.test.rf.ini
@@ -1,0 +1,18 @@
+[DEFAULT]
+version = 2021.03.29.rftest
+description = Only RF data, for use in testing how well the model performs on this out-of-domain data.
+
+[data]
+epmc_tags_query_one_filedir = data/raw/expanded_tags/EPMC_relevant_tool_pubs_3082020.csv
+epmc_tags_query_two_filedir = data/raw/expanded_tags/EPMC_relevant_pubs_query2_3082020.csv
+epmc_pmid2grants_dir = data/raw/EPMC/pmid2grants.json
+rf_tags_filedir = data/raw/expanded_tags/research_fish_manual_edit.csv
+grant_tags_filedir = data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizadditions.csv
+prodigy_filedir = data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
+grant_data_filedir = data/raw/wellcome-grants-awarded-2005-2019.csv
+sources_include = ['RF']
+
+[data_col_ranking]
+epmc_col_ranking = ['Revised code']
+grants_col_ranking = ['Revised code']
+

--- a/docs/Tech_Grants_2021.md
+++ b/docs/Tech_Grants_2021.md
@@ -189,4 +189,5 @@ Running:
 ```
 python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.ini
 ```
-will predict tech grants for the dataset given in the `grants_data_path` config variable. This gave 424 tech grants predicted in 991 grants.
+will predict tech grants for the dataset given in the `grants_data_path` config variable. This gave 2893 tech grants predicted in 16914 grants (17%) - these tagged grants are stored in `data/processed/predictions/210402/wellcome-grants-awarded-2005-2019_tagged.csv`.
+

--- a/docs/Tech_Grants_2021.md
+++ b/docs/Tech_Grants_2021.md
@@ -160,6 +160,12 @@ Thus, the ensemble model I felt best to use going forward was:
 2. The prediction probability needs to be over 0.55 in each model for the model's classification to be tech.
 3. 1 out of 1 needs to agree on a tech grant classification in order for the final classification to be tech.
 
+Running:
+```
+python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.02.ini
+```
+will evaluate the model on the test, not seen data (if there was any), and the EPMC and RF evaluation data. This will work for configs with one model in, or multiple. The output file `data/processed/ensemble/210402/evaluation_results.txt` is stored.
+
 This ensemble gives the following results on the test set:
 
 ||precision|recall |f1-score   |support|
@@ -181,6 +187,6 @@ This ensemble gives the following results on the test set:
 
 Running:
 ```
-python -i nutrition_labels/ensemble_grant_tagger.py --config_path configs/ensemble/2021.04.02.ini
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.ini
 ```
-gave 424 tech grants predicted in 991 grants.
+will predict tech grants for the dataset given in the `grants_data_path` config variable. This gave 424 tech grants predicted in 991 grants.

--- a/nutrition_labels/evaluate.py
+++ b/nutrition_labels/evaluate.py
@@ -1,0 +1,296 @@
+"""
+For a single or ensemble tech model:
+
+- Load model(s)
+- Predict on test data
+- Predict on unseen data
+- Predict on EPMC and RF data (if given)
+- Output all evaluation results
+
+Run as:
+python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.02.ini
+
+"""
+
+from argparse import ArgumentParser
+import configparser
+import os
+import json
+
+import pandas as pd
+from sklearn.metrics import (
+    classification_report,
+    confusion_matrix,
+    f1_score,
+    precision_score,
+    recall_score,
+    accuracy_score
+)
+
+from nutrition_labels.grant_tagger import GrantTagger
+from nutrition_labels.ensemble_grant_tagger import EnsembleGrantTagger
+from nutrition_labels.utils import pretty_confusion_matrix
+
+def merge_grants(eval_data, grant_data, eval_id_col, grant_id_col, label_name):
+    eval_data = pd.merge(
+            eval_data,
+            grant_data,
+            how="left",
+            left_on=eval_id_col,
+            right_on=grant_id_col
+        )
+    eval_data[label_name] = eval_data[label_name].astype(int)
+    return eval_data
+
+def get_training_data(model_dir, grant_id_col):
+    
+    training_info_file = os.path.join(model_dir, 'training_information.json')
+    with open(training_info_file, 'r') as file:
+        for line in file:
+            model_data = json.loads(line)
+            model_name = list(model_data.keys())[0]
+            # The ground truth will be the same for every model, so no need to read every line
+            break
+    training_data = [(grant_id, m['Truth'], m['Test/train']) for grant_id, m in model_data[model_name].items()]
+    training_data = pd.DataFrame(training_data, columns = [grant_id_col, 'Truth', 'Test/train'])
+
+    return training_data
+
+class EvaluateGrantTagger():
+
+    def __init__(
+        self,
+        model_dirs,
+        grant_text_cols=['Title', 'Synopsis'],
+        grant_id_col='Reference',
+        pred_prob_thresh=None,
+        epmc_file_dir=None,
+        rf_file_dir=None,
+        eval_id_col=None,
+        eval_label_name=None,
+        average = "binary"
+        ):
+        self.model_dirs = model_dirs
+        self.grant_text_cols = grant_text_cols
+        self.grant_id_col = grant_id_col
+        self.pred_prob_thresh = pred_prob_thresh
+        self.epmc_file_dir = epmc_file_dir
+        self.rf_file_dir = rf_file_dir
+        self.eval_id_col = eval_id_col
+        self.eval_label_name = eval_label_name
+        self.average = average
+
+    def load_grant_data(self, grants_data_path):
+
+        grant_data = pd.read_csv(grants_data_path)
+        self.grant_data = grant_data.drop_duplicates(subset=self.grant_id_col)[self.grant_text_cols + [self.grant_id_col]] # Don't need it all
+
+    def load_training_data(self, training_label_name='Truth'):
+        # Training data
+        model_dir = os.path.dirname(self.model_dirs[0]) # It's the same directory name for all models
+        training_data = get_training_data(model_dir, self.grant_id_col)
+        self.training_label_name = training_label_name
+        self.training_data = merge_grants(training_data, self.grant_data, self.grant_id_col, self.grant_id_col, self.training_label_name)
+
+    def find_datasets_included(self):
+        # Make a list of the datasets included in this evaluation
+        datasets_included = []
+        if sum(self.training_data['Test/train'] == 'Test') != 0:
+            datasets_included.append('test')
+        if sum(self.training_data['Test/train'] == 'Not used') != 0:
+            datasets_included.append('not seen')
+        if self.epmc_file_dir:
+            datasets_included.append('EPMC')
+        if self.rf_file_dir:
+            datasets_included.append('RF')
+
+        return datasets_included
+
+    def create_test_dataset(self):
+        return self.training_data.loc[self.training_data['Test/train'] == 'Test']
+
+    def create_unseen_dataset(self):
+        return self.training_data.loc[self.training_data['Test/train'] == 'Not used']
+
+    def create_epmc_dataset(self):
+        epmc_evaluation_data = pd.read_csv(self.epmc_file_dir)
+        epmc_evaluation_data = merge_grants(epmc_evaluation_data, self.grant_data, self.eval_id_col, self.grant_id_col, self.eval_label_name)
+        return epmc_evaluation_data
+
+    def create_rf_dataset(self):
+        rf_evaluation_data = pd.read_csv(self.rf_file_dir)
+        rf_evaluation_data = merge_grants(rf_evaluation_data, self.grant_data, self.eval_id_col, self.grant_id_col, self.eval_label_name)
+        return rf_evaluation_data
+
+    def return_dataset(self, dataset_id):
+        if dataset_id == "test":
+            return {
+                "dataset": self.create_test_dataset(),
+                "label_name": self.training_label_name
+                }
+        elif dataset_id == "not seen":
+            return {
+                "dataset": self.create_unseen_dataset(),
+                "label_name": self.training_label_name
+                }
+        elif dataset_id == "EPMC":
+            return {
+                "dataset": self.create_epmc_dataset(),
+                "label_name": self.eval_label_name
+                }
+        elif dataset_id == "RF":
+            return {
+                "dataset": self.create_rf_dataset(),
+                "label_name": self.eval_label_name
+                }
+        else:
+            print("No dataset for this name")
+
+    def evaluate_single_model(self, model_dir, datasets_included):
+        
+        grant_tagger = GrantTagger(
+            threshold=self.pred_prob_thresh,
+            prediction_cols=self.grant_text_cols,
+            )
+        grant_tagger.load_model(model_dir)
+
+        dataset_scores = {}
+        for dataset_name in datasets_included:
+            dataset_info = self.return_dataset(dataset_name)
+            
+            print(f"Evaluating models on {dataset_name} dataset ...")
+
+            X_vec = grant_tagger.transform(dataset_info['dataset'])
+            y = dataset_info['dataset'][dataset_info['label_name']].tolist()
+            scores = grant_tagger.evaluate(X_vec, y, extra_scores=True, average=self.average)
+
+            dataset_scores[dataset_name] = scores
+
+        return dataset_scores
+
+    def evaluate_ensemble_model(self, model_dirs, num_agree, datasets_included):
+        
+        ensemble_grant_tagger = EnsembleGrantTagger(
+                model_dirs=model_dirs,
+                num_agree=num_agree,
+                grant_text_cols=self.grant_text_cols,
+                grant_id_col=self.grant_id_col,
+                threshold=self.pred_prob_thresh
+                )
+        dataset_scores = {}
+        for dataset_name in datasets_included:
+            dataset_info = self.return_dataset(dataset_name)
+            print(f"Evaluating models on {dataset_name} dataset ...")
+
+            grant_tagger = GrantTagger(prediction_cols=self.grant_text_cols)
+            grant_data = grant_tagger.process_grant_text(dataset_info['dataset'])
+            grants_text = dataset_info['dataset']['Grant texts'].tolist()
+            y_predict = ensemble_grant_tagger.predict(grants_text)
+            y = dataset_info['dataset'][dataset_info['label_name']].tolist()
+            scores = {
+                "size": len(y),
+                "accuracy": accuracy_score(y, y_predict),
+                "f1": f1_score(y, y_predict, average=self.average),
+                "precision_score": precision_score(
+                    y, y_predict, zero_division=0, average=self.average
+                ),
+                "recall_score": recall_score(
+                    y, y_predict, zero_division=0, average=self.average
+                ),
+            }
+            scores["Classification report"] = classification_report(y, y_predict)
+            scores["Confusion matrix"] = pretty_confusion_matrix(y, y_predict)
+
+            dataset_scores[dataset_name] = scores
+
+        return dataset_scores
+
+def output_scores(dataset_scores, output_path):
+    with open(output_path, "w") as output_file:
+        for dataset_name, scores in dataset_scores.items():
+            output_file.write("\n" + dataset_name + ":\n")
+            for score_type, score in scores.items():
+                output_file.write("\n" + score_type + ":\n" + str(score))
+
+def evaluate_models(config):
+
+    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
+    model_dirs = config["ensemble_model"]["model_dirs"].split(',')
+
+    try:
+        pred_prob_thresh = config.getfloat("ensemble_model", "pred_prob_thresh")
+    except:
+        pred_prob_thresh = None
+
+    try:
+        epmc_file_dir = config.get("prediction_data", "epmc_file_dir")
+    except:
+        epmc_file_dir = None
+
+    try:
+        rf_file_dir = config.get("prediction_data", "rf_file_dir")
+    except:
+        rf_file_dir = None
+
+    try:
+        eval_id_col = config.get("prediction_data", "eval_id_col")
+        eval_label_name = config.get("prediction_data", "eval_label_name")
+    except:
+        eval_id_col = None
+        eval_label_name = None
+
+    # Grant data parameters
+    grants_data_path = config["prediction_data"]["grants_data_path"]
+    grant_text_cols = config["prediction_data"]["grant_text_cols"].split(',')
+    grant_id_col = config["prediction_data"]["grant_id_col"]
+
+    eval_grant_tagger = EvaluateGrantTagger(
+        model_dirs=model_dirs,
+        grant_text_cols=grant_text_cols,
+        grant_id_col=grant_id_col,
+        pred_prob_thresh=pred_prob_thresh,
+        epmc_file_dir=epmc_file_dir,
+        rf_file_dir=rf_file_dir,
+        eval_id_col=eval_id_col,
+        eval_label_name=eval_label_name,
+        average='binary'
+        )
+
+    eval_grant_tagger.load_grant_data(grants_data_path)
+    training_label_name = 'Truth'
+    eval_grant_tagger.load_training_data(training_label_name)
+    datasets_included = eval_grant_tagger.find_datasets_included()
+
+    # Evaluate and output
+    
+    output_path = f'data/processed/ensemble/{config_version}/evaluation_results.txt'
+    
+    if len(model_dirs) == 1:
+        dataset_scores = eval_grant_tagger.evaluate_single_model(model_dirs[0], datasets_included)
+        output_scores(dataset_scores, output_path)
+    else:
+        num_agree = config.getint("ensemble_model", "num_agree")
+        dataset_scores = eval_grant_tagger.evaluate_ensemble_model(model_dirs, num_agree, datasets_included)
+        output_scores(dataset_scores, output_path)
+
+    return dataset_scores
+
+def parse_arguments(parser):
+
+    parser.add_argument(
+        '--config_path',
+        help='Path to config file',
+        default='configs/evaluation/2021.04.02.ini'
+    )
+
+    return parser.parse_args()
+
+if __name__ == '__main__':
+    
+    parser = ArgumentParser()
+    args = parse_arguments(parser)
+
+    config = configparser.ConfigParser()
+    config.read(args.config_path)
+
+    dataset_scores = evaluate_models(config)

--- a/nutrition_labels/evaluate.py
+++ b/nutrition_labels/evaluate.py
@@ -263,7 +263,10 @@ def evaluate_models(config):
 
     # Evaluate and output
     
-    output_path = f'data/processed/ensemble/{config_version}/evaluation_results.txt'
+    output_path = f'data/processed/evaluation/{config_version}/evaluation_results.txt'
+
+    if not os.path.exists(os.path.dirname(output_path)):
+        os.makedirs(os.path.dirname(output_path))
     
     if len(model_dirs) == 1:
         dataset_scores = eval_grant_tagger.evaluate_single_model(model_dirs[0], datasets_included)

--- a/nutrition_labels/predict.py
+++ b/nutrition_labels/predict.py
@@ -33,7 +33,7 @@ def predict_grants(config):
     grants_data_path = config["prediction_data"]["grants_data_path"] 
     config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
     input_file_name = os.path.basename(grants_data_path).split('.')[0]
-    output_path = f'data/processed/ensemble/{config_version}/{input_file_name}_tagged.csv'
+    output_path = f'data/processed/predictions/{config_version}/{input_file_name}_tagged.csv'
 
     try:
         pred_prob_thresh = config.getfloat("model_parameters", "pred_prob_thresh")

--- a/nutrition_labels/predict.py
+++ b/nutrition_labels/predict.py
@@ -1,0 +1,90 @@
+"""
+For a dataset load a model (or ensemble of models) and predict whether the grants
+are tech grants or not.
+
+Run as:
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.ini
+
+"""
+
+from argparse import ArgumentParser
+import configparser
+import os
+
+import pandas as pd
+
+from nutrition_labels.grant_tagger import GrantTagger
+from nutrition_labels.ensemble_grant_tagger import EnsembleGrantTagger
+
+def output_tagged_grants(output_path, y_pred, grant_ids):
+
+    if not os.path.exists(os.path.dirname(output_path)):
+        os.makedirs(os.path.dirname(output_path))
+
+    pd.DataFrame(
+        {
+        'Tech grant prediction': y_pred,
+        'Grant ID': grant_ids
+        }
+        ).to_csv(output_path, index=False)
+
+def predict_grants(config):
+
+    grants_data_path = config["prediction_data"]["grants_data_path"] 
+    config_version = "".join(config["DEFAULT"]["version"].split("."))[2:]
+    input_file_name = os.path.basename(grants_data_path).split('.')[0]
+    output_path = f'data/processed/ensemble/{config_version}/{input_file_name}_tagged.csv'
+
+    try:
+        pred_prob_thresh = config.getfloat("model_parameters", "pred_prob_thresh")
+    except:
+        pred_prob_thresh = None
+
+    model_dirs = config["model_parameters"]["model_dirs"].split(',')
+    grant_text_cols = config["prediction_data"]["grant_text_cols"].split(',')
+    grant_id_col = config["prediction_data"]["grant_id_col"]
+
+    grants_data = pd.read_csv(grants_data_path)
+    grant_ids = grants_data[grant_id_col].tolist()
+
+    if len(model_dirs) == 1:
+        model_dir = model_dirs[0]
+        grant_tagger = GrantTagger(
+            threshold=pred_prob_thresh,
+            prediction_cols=grant_text_cols,
+            )
+        grant_tagger.load_model(model_dir)
+        X_vec = grant_tagger.transform(grants_data)
+        y_pred = grant_tagger.predict(X_vec)
+    else:
+        tech_grant_model = EnsembleGrantTagger(
+            model_dirs=model_dirs,
+            num_agree=config.getint("model_parameters", "num_agree"),
+            grant_text_cols=grant_text_cols,
+            grant_id_col=grant_id_col,
+            threshold=pred_prob_thresh
+            )
+        grants_text = tech_grant_model.load_grants_text(grants_data_path)
+        y_pred = tech_grant_model.predict(grants_text)
+
+    output_tagged_grants(output_path, y_pred, grant_ids)
+
+    return grant_ids, y_pred
+
+if __name__ == '__main__':
+    parser = ArgumentParser()
+
+    parser.add_argument(
+        '--config_path',
+        help='Path to config file',
+        default='configs/predict/2021.04.02.ini'
+    )
+
+    args = parser.parse_args()
+
+    config = configparser.ConfigParser()
+    config.read(args.config_path)
+
+    grant_ids, y_pred = predict_grants(config)
+
+    print(f'{sum(y_pred)} tech grants predicted in {len(y_pred)} grants')

--- a/tech_grants_pipeline.sh
+++ b/tech_grants_pipeline.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export PYTHONPATH='.'
-# Creating training data
-python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.ini &
-# Creating evaluation data
-python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.epmc.ini &
-python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.rf.ini &
-# Training models
-python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.03.ini &
-# Predicting tech grants
-python nutrition_labels/predict.py --config_path configs/predict/2021.04.04.ini &
-# Evaluating tech grants
+echo 'Creating training data ...'
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.ini
+echo 'Creating evaluation data ...'
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.epmc.ini
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.rf.ini
+echo 'Training models ...'
+python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.03.ini
+echo 'Predicting tech grants ...'
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.04.ini
+echo 'Evaluating tech grants ...'
 python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.03.ini

--- a/tech_grants_pipeline.sh
+++ b/tech_grants_pipeline.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+export PYTHONPATH='.'
+# Creating training data
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.ini &
+# Creating evaluation data
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.epmc.ini &
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.rf.ini &
+# Training models
+python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.03.ini &
+# Predicting tech grants
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.04.ini &
+# Evaluating tech grants
+python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.03.ini

--- a/tech_grants_pipeline_test.sh
+++ b/tech_grants_pipeline_test.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 export PYTHONPATH='.'
-# Creating training data
-python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.test.ini &
-# Creating evaluation data
-python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.test.epmc.ini &
-python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.test.rf.ini &
-# Training models
-python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.02.test.ini &
-# Predicting tech grants
-python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.test.ini &
-# Evaluating tech grants
+echo 'Creating training data ...'
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.test.ini
+echo 'Creating evaluation data ...'
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.test.epmc.ini
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.test.rf.ini
+echo 'Training models ...'
+python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.02.test.ini
+echo 'Predicting tech grants ...'
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.test.ini
+echo 'Evaluating tech grants ...'
 python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.02.test.ini

--- a/tech_grants_pipeline_test.sh
+++ b/tech_grants_pipeline_test.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+export PYTHONPATH='.'
+# Creating training data
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.08.test.ini &
+# Creating evaluation data
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.test.epmc.ini &
+python nutrition_labels/create_training_data.py --config_path configs/training_data/2021.03.29.test.rf.ini &
+# Training models
+python nutrition_labels/grant_tagger.py --config_path configs/train_model/2021.04.02.test.ini &
+# Predicting tech grants
+python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.test.ini &
+# Evaluating tech grants
+python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.02.test.ini

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,69 @@
+import pytest
+import os
+import json
+
+import pandas as pd
+
+from nutrition_labels.evaluate import get_training_data, EvaluateGrantTagger
+
+model_scores = [
+    {
+        "model_1": {
+            "id_A": {"Truth": 1, "Prediction": 1, "Test/train": "Train"},
+            "id_B": { "Truth": 0, "Prediction": 1, "Test/train": "Test"},
+            "id_C": {"Truth": 1, "Prediction": 0, "Test/train": "Test"},
+            "id_D": {"Truth": 0, "Prediction": 1, "Test/train": "Test"}
+            }
+    },
+    {
+        "model_2": {
+            "id_A": {"Truth": 1, "Prediction": 1, "Test/train": "Train"},
+            "id_B": { "Truth": 0, "Prediction": 0, "Test/train": "Test"},
+            "id_C": {"Truth": 1, "Prediction": 1, "Test/train": "Test"},
+            "id_D": {"Truth": 0, "Prediction": 0, "Test/train": "Test"}
+            }
+    },
+    ]
+
+expected_training_data = pd.DataFrame([
+        {'Grant ID': 'id_A', 'Truth': 1, 'Test/train': 'Train'},
+        {'Grant ID': 'id_B', 'Truth': 0, 'Test/train': 'Test'},
+        {'Grant ID': 'id_C', 'Truth': 1, 'Test/train': 'Test'},
+        {'Grant ID': 'id_D', 'Truth': 0, 'Test/train': 'Test'}
+        ])
+
+def test_get_training_data(tmp_path):
+
+    with open(os.path.join(tmp_path, "training_information.json"), "a") as f:
+        for line in model_scores:
+            f.write(json.dumps(line))
+            f.write('\n')
+    training_data = get_training_data(tmp_path, grant_id_col='Grant ID')
+
+    assert training_data.equals(expected_training_data)
+
+def test_find_datasets_included():
+
+    eval_grant_tagger = EvaluateGrantTagger(
+            model_dirs=['model_dir'],
+            epmc_file_dir='epmc_file_dir.csv',
+            rf_file_dir='rf_file_dir.csv'
+            )
+    eval_grant_tagger.training_data = expected_training_data
+    datasets_included = eval_grant_tagger.find_datasets_included()
+
+    assert set(datasets_included) == set(['test', 'EPMC', 'RF'])
+
+def test_return_dataset():
+
+    eval_grant_tagger = EvaluateGrantTagger(
+            model_dirs=['model_dir']
+            )
+    eval_grant_tagger.training_data = expected_training_data
+    eval_grant_tagger.training_label_name = 'Truth'
+
+    dataset_info = eval_grant_tagger.return_dataset("test")
+    
+    assert len(dataset_info["dataset"]) == 3
+    assert 'id_A' not in dataset_info["dataset"]['Grant ID']
+    assert dataset_info["label_name"] == 'Truth'


### PR DESCRIPTION
Addressing https://trello.com/c/bZltnIVx/1225-handy-evaluate-and-predict-functions-for-tech-model

Other scripts contained parts of these, but the new `evaluate.py` and `predict.py` mean that an ensemble of models, or a single model can be evaluated, and used to make new predictions with in a more streamlined way for the pipeline. i.e. for the first time you can run
```
python nutrition_labels/evaluate.py --config_path configs/evaluation/2021.04.02.ini
```
and
```
python nutrition_labels/predict.py --config_path configs/predict/2021.04.02.ini
```
for either single or ensembles of models (depending what youve included in the config).

## Results

Predicting on all 360 giving grants data gave 2893 tech grants predicted in 16914 grants (17%).