### PR TITLE
Remove use of trained models from tests

### DIFF
--- a/latest_files.txt
+++ b/latest_files.txt
@@ -10,3 +10,10 @@ data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizaddition
 data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
 data/raw/wellcome-grants-awarded-2005-2019_test_sample.csv
 data/raw/wellcome-grants-awarded-2005-2019.csv
+data/processed/clustering/cluster_info_210429.txt
+data/processed/clustering/tech_cluster_info_210429.txt
+data/processed/evaluation/210402/evaluation_results.txt
+data/processed/evaluation/210404/evaluation_results.txt
+data/processed/fairness/fairness_results_210402.csv
+data/processed/predictions/210406/wellcome-grants-awarded-2005-2019_tagged.csv
+data/processed/predictions/210403/all_grants_fortytwo_info_210420_tagged.csv

--- a/latest_files.txt
+++ b/latest_files.txt
@@ -10,4 +10,3 @@ data/raw/expanded_tags/wellcome-grants-awarded-2005-2019_manual_edit_Lizaddition
 data/prodigy/merged_tech_grants/merged_tech_grants.jsonl
 data/raw/wellcome-grants-awarded-2005-2019_test_sample.csv
 data/raw/wellcome-grants-awarded-2005-2019.csv
-models/210331/

--- a/tests/test_tech_grant_tagger.py
+++ b/tests/test_tech_grant_tagger.py
@@ -4,20 +4,28 @@ import os
 import pandas as pd
 
 from nutrition_labels.ensemble_grant_tagger import EnsembleGrantTagger
-
+from nutrition_labels.grant_tagger import GrantTagger
 
 grants_data = pd.DataFrame([
-    {'ID': 123, 'Title': 'This is a title about a grant'},
-    {'ID': 456, 'Title': 'Research about cancer cells'},
-    {'ID': 789, 'Title': 'We will build a python based mathematical model with open source code on github'}])
+    {'ID': 123, 'Title': 'This is a title about a grant', 'Relevance code': 0},
+    {'ID': 456, 'Title': 'Research about cancer cells', 'Relevance code': 0},
+    {'ID': 789, 'Title': 'We will build a python based mathematical model with open source code on github', 'Relevance code': 1}])
+
+X_train = grants_data['Title'].tolist()
+y_train = grants_data['Relevance code'].tolist()
 
 def test_load_grants_text(tmp_path):
 
     grants_data_dir = os.path.join(tmp_path, 'test.csv')
     grants_data.to_csv(grants_data_dir)
 
+    model_dir = os.path.join(tmp_path, 'model_name')
+    grant_tagger = GrantTagger(vectorizer_type='count', classifier_type='naive_bayes')
+    grant_tagger.fit(X_train, y_train)
+    grant_tagger.save_model(model_dir)
+
     tech_grant_model = EnsembleGrantTagger(
-        model_dirs=['models/210331/count_naive_bayes_210331'],
+        model_dirs=[model_dir],
         num_agree=1,
         grant_text_cols=['Title'],
         grant_id_col='ID')
@@ -30,8 +38,13 @@ def test_predict(tmp_path):
     grants_data_dir = os.path.join(tmp_path, 'test.csv')
     grants_data.to_csv(grants_data_dir)
 
+    model_dir = os.path.join(tmp_path, 'model_name')
+    grant_tagger = GrantTagger(vectorizer_type='count', classifier_type='naive_bayes')
+    grant_tagger.fit(X_train, y_train)
+    grant_tagger.save_model(model_dir)
+
     tech_grant_model = EnsembleGrantTagger(
-        model_dirs=['models/210331/count_naive_bayes_210331'],
+        model_dirs=[model_dir],
         num_agree=1,
         grant_text_cols=['Title'],
         grant_id_col='ID')


### PR DESCRIPTION
Removing the need for any downloaded trained models from the tests.

Addressing https://github.com/wellcometrust/nutrition-labels/issues/81

Also updated `latest_files.txt` to include some of the latest results from `data/processed/`. I'm not sure if this file is really serving a function, but `make sync_latest_files_from_s3` is preferable to `make sync_data_from_s3` if you did want to get the "main" data files for this project. You should have all the data needed to run any config file anyway!