### PR TITLE
Add setup.py

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,7 @@ $(VIRTUALENV)/.installed: requirements.txt
 	@mkdir -p $(VIRTUALENV)
 	virtualenv --python python3 $(VIRTUALENV)
 	$(VIRTUALENV)/bin/pip3 install -r requirements.txt
+	$(VIRTUALENV)/bin/python setup.py develop
 	touch $@
 
 .PHONY: virtualenv

--- a/pipelines/tech_grants_pipeline.sh
+++ b/pipelines/tech_grants_pipeline.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export PYTHONPATH='.'
 
 set -e
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,29 @@
+import os
+
+import setuptools
+
+with open("README.md", "r") as f:
+    long_description = f.read()
+
+setuptools.setup(
+    name="Nutrition Labels",
+    version="",
+    author="Liz Gallagher",
+    author_email="e.gallagher@wellcome.ac.uk",
+    description="Train a model to predict whether a grant contains tech or not",
+    long_description="",
+    long_description_content_type="text/markdown",
+    url="",
+    license="",
+    packages=setuptools.find_packages(
+        include=["nutrition_labels", "representation_labels"],
+        exclude=["notebooks", "tests", "build", "data", "models"]
+    ),
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Operating System :: OS Independent",
+    ],
+    tests_require=[
+        "pytest"
+    ]
+)


### PR DESCRIPTION
Adds a `setup.py` which removes the need for pythonpath in pipeline.

Please can you test the test pipeline works ok with:
```
pipelines/tech_grants_pipeline.sh configs/pipeline/2021.05.01.test.ini
```

(you may need to run `chmod +x pipelines/tech_grants_pipeline.sh`)